### PR TITLE
Fixed bug where profile dialog was showing on vacancy applies even if the user had a profile

### DIFF
--- a/src/containers/ViewVacancyDetails/Header/Header.js
+++ b/src/containers/ViewVacancyDetails/Header/Header.js
@@ -33,6 +33,8 @@ const header = (props) => {
 			await checkUserAlreadyApplied();
 			if (!user.hasProfile) {
 				await checkHasProfile();
+			} else {
+				setHasProfile(true);
 			}
 			setIsLoading(false);
 		})();


### PR DESCRIPTION
This is a quick one liner fix.

Bre noticed the 'please get a profile before you apply to the vacancies' dialog was showing up even when the user had a profile.

This PR fixes that problem.

FWIW I wonder if the bug was a regression from when we changed where the hasProfile flag was being maintained.