### PR TITLE
Focus area option for stadman only

### DIFF
--- a/src/constants/checkAuth.js
+++ b/src/constants/checkAuth.js
@@ -15,6 +15,7 @@ export const checkAuth = async (setIsLoading, setAuth) => {
             lastInitial: data.user.last_initial,
             uid: data.user.user_id,
             hasProfile: data.has_profile,
+            tenant: data.user.tenant,
             isChair: data.is_chair,
             isManager: data.is_manager,
             isExecSec: data.is_exec_sec,

--- a/src/containers/CreateVacancy/Forms/BasicInfo/BasicInfo.js
+++ b/src/containers/CreateVacancy/Forms/BasicInfo/BasicInfo.js
@@ -1,5 +1,5 @@
 import { Form, Input, Slider, DatePicker, Tooltip, Checkbox } from 'antd';
-
+import useAuth from '../../../../hooks/useAuth';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 import RequiredDocsList from './RequiredDocsList/RequiredDocsList';
@@ -13,6 +13,9 @@ const basicInformation = (props) => {
 	const formInstance = props.formInstance;
 	const initialValues = props.initialValues;
 	const readOnly = props.readOnly;
+
+	const { auth } = useAuth();
+	const { user } = auth;
 
 	const sliderMarks = {
 		0: '0',
@@ -108,7 +111,7 @@ const basicInformation = (props) => {
 				</div>
 			</div>
 
-			{ (true) ?	// TODO: replace "true" with an auth / user indicator that is true if the vacancy manager is stadman
+			{ (user?.tenant.trim().toLowerCase() === "stadtman") ?	// TODO: replace "true" with an auth / user indicator that is true if the vacancy manager is stadman
 				<Form.Item
 					label='Focus Area Selection'
 					name='requireFocusArea'

--- a/src/containers/CreateVacancy/Forms/BasicInfo/BasicInfo.js
+++ b/src/containers/CreateVacancy/Forms/BasicInfo/BasicInfo.js
@@ -108,14 +108,17 @@ const basicInformation = (props) => {
 				</div>
 			</div>
 
-			<Form.Item
-				label='Focus Area Selection'
-				name='requireFocusArea'
-				valuePropName='checked'
-				style={{ margin: '0px', paddingLeft: '10px', paddingBottom: '10px' }}
-			>
-				<Checkbox>Enable focus area</Checkbox>
-			</Form.Item>
+			{ (true) ?	// TODO: replace "true" with an auth / user indicator that is true if the vacancy manager is stadman
+				<Form.Item
+					label='Focus Area Selection'
+					name='requireFocusArea'
+					valuePropName='checked'
+					style={{ margin: '0px', paddingLeft: '10px', paddingBottom: '10px' }}
+				>
+					<Checkbox>Enable focus area</Checkbox>
+				</Form.Item>
+				: null
+			}
 
 			<Form.Item
 				label='Vacancy Description'


### PR DESCRIPTION
The option in vacancy manager to enable focus areas in the vacancy is now only visible for vacancy managers with a tenant status of "stadtman".

![image](https://github.com/CBIIT/app-tracker/assets/126281472/d4ba5094-0ff0-442a-a40f-2172a39ddc44)

