### PR TITLE
Better handling for when Service Now returns object for focus area

### DIFF
--- a/src/containers/Application/Util/TransformJsonFromBackend.js
+++ b/src/containers/Application/Util/TransformJsonFromBackend.js
@@ -1,11 +1,19 @@
 export const transformJsonFromBackend = (backendJson) => {
 
 	const cleanseFocusArea = (localFocusAreas) => {
-		if (!localFocusAreas || localFocusAreas.length == 0 || localFocusAreas.includes("undefined"))
+		if (!localFocusAreas || localFocusAreas.length == 0 )
 			return [];
-		else
-			return localFocusAreas.split(',');
-	};
+		else {
+			var innerFocusAreas = localFocusAreas;
+			if (typeof localFocusAreas !== "string") {
+				innerFocusAreas = localFocusAreas["focus_area"];
+			}
+			if (innerFocusAreas.includes("undefined")) {
+				return [];
+			}
+			return innerFocusAreas.split(',');
+		}
+	}; 
 
 	return {
 		vacancyId: backendJson.basic_info.vacancy.value,

--- a/src/containers/Apply/Util/TransformJsonFromBackend.js
+++ b/src/containers/Apply/Util/TransformJsonFromBackend.js
@@ -1,10 +1,18 @@
 export const transformJsonFromBackend = (sourceJson) => {
 
 	 const cleanseFocusArea = (localFocusAreas) => {
-		if (!localFocusAreas || localFocusAreas.length == 0 || localFocusAreas.includes("undefined"))
+		if (!localFocusAreas || localFocusAreas.length == 0 )
 			return [];
-		else
-			return localFocusAreas.split(',');
+		else {
+			var innerFocusAreas = localFocusAreas;
+			if (typeof localFocusAreas !== "string") {
+				innerFocusAreas = localFocusAreas["focus_area"];
+			}
+			if (innerFocusAreas.includes("undefined")) {
+				return [];
+			}
+			return innerFocusAreas.split(',');
+		}
 	}; 
 
 	return {

--- a/src/containers/Profile/Util/ConvertDataFromBackend.js
+++ b/src/containers/Profile/Util/ConvertDataFromBackend.js
@@ -18,10 +18,18 @@ export const convertDataFromBackend = (data) => {
 	}
 
 	const cleanseFocusArea = (localFocusAreas) => {
-		if (!localFocusAreas || localFocusAreas.length == 0 || localFocusAreas.includes("undefined"))
+		if (!localFocusAreas || localFocusAreas.length == 0 )
 			return [];
-		else
-			return localFocusAreas.split(',');
+		else {
+			var innerFocusAreas = localFocusAreas;
+			if (typeof localFocusAreas !== "string") {
+				innerFocusAreas = localFocusAreas["focus_area"];
+			}
+			if (innerFocusAreas.includes("undefined")) {
+				return [];
+			}
+			return innerFocusAreas.split(',');
+		}
 	}; 
 
 	return {


### PR DESCRIPTION
Currently Service Now is occasionally returning focus area information inside another object named focus_area:

![image](https://github.com/CBIIT/app-tracker/assets/126281472/139252be-4954-4488-9cd9-e285f80f44a4)

This change enables the React FE to reflectively determine what it is dealing with and handling it selectively.

Earlier the editing application screen would fail.