### PR TITLE
Removed visible error when user's profile is not accessible.

### DIFF
--- a/src/containers/ViewVacancyDetails/Header/Header.js
+++ b/src/containers/ViewVacancyDetails/Header/Header.js
@@ -58,7 +58,7 @@ const header = (props) => {
 			const response = await axios.get(CHECK_HAS_PROFILE);
 			setHasProfile(response.data.result.exists);
 		} catch (e) {
-			message.error('Sorry! An error occured while searching for your profile.');
+			console.log('Failed to find user profile.');
 		}
 	}
 


### PR DESCRIPTION
See:
https://tracker.nci.nih.gov/browse/APPTRACK-816

The message is now gone.

![image](https://github.com/CBIIT/app-tracker/assets/126281472/8fed1bb3-6683-4f9f-9e64-cc57133f31d0)

I'm seeing a solicitation for credentials that Justin didn't not report earlier, so I'm guessing this is just an artifact of local React. (or how the software is designed?). In any case, removing the message and adding a log is not going to provoke an auth request from the user.
