### PR TITLE
Clean up IC code

### DIFF
--- a/src/containers/CreateVacancy/Forms/BasicInfo/BasicInfo.js
+++ b/src/containers/CreateVacancy/Forms/BasicInfo/BasicInfo.js
@@ -75,9 +75,6 @@ const basicInformation = (props) => {
 			const vacancyOptionsResponse = await axios.get(
 				GET_VACANCY_OPTIONS
 			);
-			formInstance.setFieldsValue({
-				ic: vacancyOptionsResponse.data.result.ic,
-			});
 			if (vacancyOptionsResponse.data.result.isOWM){
 				setCurrentPositionMenu(positionClassificationT42OWMMenu);
 				setIsOWM(vacancyOptionsResponse.data.result.isOWM);

--- a/src/containers/CreateVacancy/Util/TransformJsonFromBackend.js
+++ b/src/containers/CreateVacancy/Util/TransformJsonFromBackend.js
@@ -22,7 +22,6 @@ export const transformJsonFromBackend = (sourceJson) => {
 			description: sourceJson.basic_info.vacancy_description.value,
 			appointmentPackageIndicator: sourceJson.basic_info.package_initiator.value,
 			positionClassification: sourceJson.basic_info.title_42_position_classification.value,
-			ic: sourceJson.basic_info.ic.value,
 			applicationDocuments: sourceJson.vacancy_documents.map((doc) => ({
 				sys_id: doc.sys_id.value,
 				document: doc.title.value,

--- a/src/containers/CreateVacancy/Util/TransformJsonToBackend.js
+++ b/src/containers/CreateVacancy/Util/TransformJsonToBackend.js
@@ -25,7 +25,6 @@ const transformBasicInfo = (basicInfo, mandatoryStatements, sysId) => {
 		vacancy_description: basicInfo.description,
 		package_initiator: basicInfo.appointmentPackageIndicator,
 		title_42_position_classification: basicInfo.positionClassification,
-		ic: (basicInfo.ic) ? basicInfo.ic : null,
 		open_date: getDateFromDateTime(basicInfo.openDate),
 		close_date: getDateFromDateTime(basicInfo.closeDate),
 		scoring_due_by_date: getDateFromDateTime(basicInfo.scoringDueByDate),

--- a/src/containers/ManageDashboard/Util/TransformJsonFromBackend.js
+++ b/src/containers/ManageDashboard/Util/TransformJsonFromBackend.js
@@ -19,7 +19,6 @@ export const transformJsonFromBackend = (sourceJson) => {
 			description: sourceJson.basic_info.vacancy_description.value,
 			appointmentPackageIndicator: sourceJson.basic_info.package_initiator.value,
 			positionClassification: sourceJson.basic_info.title_42_position_classification.value,
-			ic: sourceJson.basic_info.ic.value,
 			applicationDocuments: sourceJson.vacancy_documents.map((doc) => ({
 				document: doc.title.value,
 				isDocumentOptional: doc.is_optional.value == '1' ? true : false,


### PR DESCRIPTION
Following Bre's successful simplification of the back end code, React no longer needs to receive or send requests with the IC code for new vacancies.

This functionality has been removed and dev tested.