### PR TITLE
background fix (gray to white per mockup)

### DIFF
--- a/src/components/Header/Login/Login.css
+++ b/src/components/Header/Login/Login.css
@@ -20,6 +20,7 @@
 	text-decoration: underline;
 	font-weight: bold;
 	margin: auto;
+	background-color: white;
 }
 
 .CustomIcon {


### PR DESCRIPTION
SCSS team requested a solid white background for the login options.

I'm not sure how this .ant-d css class took precedence, but it's solid white now.

![image](https://github.com/CBIIT/app-tracker/assets/126281472/0b131ac9-0efe-4db2-8d63-45bb1b988791)
