### PR TITLE
"Organizational code" now required for vacancies

### DIFF
--- a/src/containers/CreateVacancy/Forms/BasicInfo/BasicInfo.js
+++ b/src/containers/CreateVacancy/Forms/BasicInfo/BasicInfo.js
@@ -352,6 +352,7 @@ const basicInformation = (props) => {
 				<div className='DatePicker'>
 					<EditableDropDown
 						name='sacCode'
+						required={true}
 						showSearch={true}
 						menu={sacCodes}
 						filterOption={(input, option) =>

--- a/src/containers/CreateVacancy/Forms/FinalizeVacancy/FinalizeVacancy.js
+++ b/src/containers/CreateVacancy/Forms/FinalizeVacancy/FinalizeVacancy.js
@@ -120,7 +120,7 @@ const finalizeVacancy = (props) => {
 						{basicInfo.numberOfRecommendations} recommendations
 					</li>
 				</ul>
-				<h2>Organization Code</h2>
+				<h2>Organizational Code</h2>
 				<ul>
 					<p>
 						{basicInfo.sacCode}


### PR DESCRIPTION
**Changes**

- Made "organizational code" in vacancy manager a required field for new vacancies
- Rephrased "organization code" on the finalize vacancy screen to "organizational code"

![image](https://github.com/CBIIT/app-tracker/assets/126281472/8d79e949-5ad9-46c0-b926-53a3c0a8248e)
