### PR TITLE
Apptrack 999 duplicate files redux

### DIFF
--- a/src/containers/Apply/Apply.js
+++ b/src/containers/Apply/Apply.js
@@ -131,11 +131,19 @@ const Apply = ({ initialValues, editSubmitted }) => {
 			initialValues.applicantDocuments &&
 			initialValues.applicantDocuments.length > 0
 		) {
+			// mlh: looks like slightly different ontologies coming back from SNow ?
 			initialValues.applicantDocuments.forEach((applicantDocument) => {
-				applicantDocuments[applicantDocument.title.label] = {
-					...applicantDocuments[applicantDocument.title.label],
-					...applicantDocument,
-				};
+				if (applicantDocument && applicantDocument.title && applicantDocument.title.label) {
+					applicantDocuments[applicantDocument.title.label] = {
+						...applicantDocuments[applicantDocument.title.label],
+						...applicantDocument,
+					};
+				} else {
+					applicantDocuments[applicantDocument.documentName] = {
+						...applicantDocuments[applicantDocument.documentName],
+						...applicantDocument,
+					};
+				}
 			});
 		}
 

--- a/src/containers/Apply/Apply.js
+++ b/src/containers/Apply/Apply.js
@@ -136,8 +136,18 @@ const Apply = ({ initialValues, editSubmitted }) => {
 				if (applicantDocument && applicantDocument.title && applicantDocument.title.label) {
 					applicantDocuments[applicantDocument.title.label] = {
 						...applicantDocuments[applicantDocument.title.label],
-						...applicantDocument,
+						...applicantDocument
 					};
+					var initialFiles = initialValues.applicantDocuments.filter(iv => iv.title.label === applicantDocument.title.label);
+					if (initialFiles != null && initialFiles.length > 0) {
+						applicantDocuments[applicantDocument.title.label].file = initialFiles[0].file;
+						//applicantDocuments[applicantDocument.title.label].uploadedDocument.fileName = initialFiles[0].file.fileList[0].name;
+						if (initialFiles[0].file.fileList.length > 0) {
+							applicantDocuments[applicantDocument.title.label].uploadedDocument = {
+								fileName : initialFiles[0].file.fileList[0].name
+							};
+						}
+					}
 				} else {
 					applicantDocuments[applicantDocument.documentName] = {
 						...applicantDocuments[applicantDocument.documentName],

--- a/src/containers/Apply/Apply.js
+++ b/src/containers/Apply/Apply.js
@@ -161,7 +161,7 @@ const Apply = ({ initialValues, editSubmitted }) => {
 		const formData = {
 			...initialValues,
 			applicantDocuments: Object.values(applicantDocuments),
-			questions: (initialValues) ? initialValues.questions : demographics,
+			questions: ((initialValues) && initialValues.questions) ? initialValues.questions : demographics,
 			basicInfo: basicInfo,
 			address: address
 		};

--- a/src/containers/Apply/Apply.js
+++ b/src/containers/Apply/Apply.js
@@ -131,7 +131,6 @@ const Apply = ({ initialValues, editSubmitted }) => {
 			initialValues.applicantDocuments &&
 			initialValues.applicantDocuments.length > 0
 		) {
-			// mlh: looks like slightly different ontologies coming back from SNow ?
 			initialValues.applicantDocuments.forEach((applicantDocument) => {
 				if (applicantDocument && applicantDocument.title && applicantDocument.title.label) {
 					applicantDocuments[applicantDocument.title.label] = {
@@ -141,10 +140,12 @@ const Apply = ({ initialValues, editSubmitted }) => {
 					var initialFiles = initialValues.applicantDocuments.filter(iv => iv.title.label === applicantDocument.title.label);
 					if (initialFiles != null && initialFiles.length > 0) {
 						applicantDocuments[applicantDocument.title.label].file = initialFiles[0].file;
-						//applicantDocuments[applicantDocument.title.label].uploadedDocument.fileName = initialFiles[0].file.fileList[0].name;
 						if (initialFiles[0].file.fileList.length > 0) {
 							applicantDocuments[applicantDocument.title.label].uploadedDocument = {
-								fileName : initialFiles[0].file.fileList[0].name
+								fileName : initialFiles[0].uploadedDocument.fileName,
+								attachSysId : initialFiles[0].uploadedDocument.attachSysId,
+								downloadLink : initialFiles[0].uploadedDocument.downloadLink,
+								markedToDelete : initialFiles[0].uploadedDocument.markedToDelete
 							};
 						}
 					}

--- a/src/containers/Apply/Apply.js
+++ b/src/containers/Apply/Apply.js
@@ -142,10 +142,10 @@ const Apply = ({ initialValues, editSubmitted }) => {
 						applicantDocuments[applicantDocument.title.label].file = initialFiles[0].file;
 						if (initialFiles[0].file.fileList.length > 0) {
 							applicantDocuments[applicantDocument.title.label].uploadedDocument = {
-								fileName : initialFiles[0].uploadedDocument.fileName,
-								attachSysId : initialFiles[0].uploadedDocument.attachSysId,
-								downloadLink : initialFiles[0].uploadedDocument.downloadLink,
-								markedToDelete : initialFiles[0].uploadedDocument.markedToDelete
+								fileName : initialFiles[0]?.uploadedDocument?.fileName,
+								attachSysId : initialFiles[0]?.uploadedDocument?.attachSysId,
+								downloadLink : initialFiles[0]?.uploadedDocument?.downloadLink,
+								markedToDelete : initialFiles[0]?.uploadedDocument?.markedToDelete
 							};
 						}
 					}

--- a/src/containers/Apply/Apply.js
+++ b/src/containers/Apply/Apply.js
@@ -161,7 +161,7 @@ const Apply = ({ initialValues, editSubmitted }) => {
 		const formData = {
 			...initialValues,
 			applicantDocuments: Object.values(applicantDocuments),
-			questions: demographics,
+			questions: (initialValues) ? initialValues.questions : demographics,
 			basicInfo: basicInfo,
 			address: address
 		};


### PR DESCRIPTION
**Changes**

- Attached documents in a draft application that have been reloaded no longer have duplicates
- Attached documents in a draft application that have been reloaded now have filenames (and links, trash icon, etc)
- Draft applications that are reloaded now have demographic information from the last application save (and not whatever was in the profile)