### PR TITLE
Member (non-voting) - Hide the option

### DIFF
--- a/src/containers/CreateVacancy/Forms/VacancyCommittee/EditableTable/EditableCell/EditableCell.js
+++ b/src/containers/CreateVacancy/Forms/VacancyCommittee/EditableTable/EditableCell/EditableCell.js
@@ -26,9 +26,6 @@ const editableCell = ({
 					<Select>
 						<Option value={COMMITTEE_CHAIR}>Chair</Option>
 						<Option value={COMMITTEE_MEMBER_VOTING}>Member (voting)</Option>
-						<Option value={COMMITTEE_MEMBER_NON_VOTING}>
-							Member (non-voting)
-						</Option>
 						<Option value={COMMITTEE_HR_SPECIALIST}>
 							HR Specialist (non-voting)
 						</Option>


### PR DESCRIPTION
As a Vacancy Manager I do not want to be able to assign users as a Member (non-voting) when creating a Vacancy so that they can score Applicants.

Remove the option of the "Member (non-voting)" role in the list of Roles on the Vacancy Committee page when creating a Vacancy. 