### PR TITLE
Alert message

### DIFF
--- a/src/components/UI/EditableField/EditableField.js
+++ b/src/components/UI/EditableField/EditableField.js
@@ -15,7 +15,7 @@ const editableField = (props) =>
 				}
 			]}
 		>
-			<Input />
+			<Input required={props.required} />
 		</Form.Item>
 	) : (
 		<Form.Item
@@ -25,7 +25,7 @@ const editableField = (props) =>
 				{ required: props.required, message: 'Please provide an answer.' },
 			]}
 		>
-			<Input />
+			<Input required={props.required} />
 		</Form.Item>
 	);
 


### PR DESCRIPTION
When an authenticated Okta applicant Users is on a profile information page, and no profile fields are filled in and User clicks Save button, only phone number alert is displayed versus all the required fields alerts.

STEPS TO REPRODUCE:
Given a new Okta User Applicant logged in
And User has no profile details set up yet
When User clicks on Save button on Profile page
Then User can see a phone number alert only