### PR TITLE
updated the label of the Institute/Office/Program column to "Institute"

### DIFF
--- a/src/containers/Home/Home.js
+++ b/src/containers/Home/Home.js
@@ -16,7 +16,7 @@ const columns = [
 		sortDirections: ['descend'],
 	},
 	{
-		title: 'Institute/Office/Program',
+		title: 'Institute',
 		dataIndex: 'office',
 		sorter: (a, b) => a.office.length - b.office.length,
 	},


### PR DESCRIPTION
GIVEN a Vacancy Manager is logged in

WHEN the user goes to the SSJ Home Page

THEN there is a column that reads "Institute" in the Open Vacancies table

 

GIVEN an Applicant is logged in

WHEN the user goes to the SSJ Home Page

THEN there is a column that reads "Institute" in the Open Vacancies table