### PR TITLE
adjusted height for notification.error

### DIFF
--- a/src/containers/Apply/Apply.js
+++ b/src/containers/Apply/Apply.js
@@ -120,7 +120,7 @@ const Apply = ({ initialValues, editSubmitted }) => {
 			</>,
 			duration: 30,
 				style: {
-					height: "25vh",
+					height: "225px",
 					display: 'flex',
 					alignItems: 'center'
 				}
@@ -210,7 +210,7 @@ const Apply = ({ initialValues, editSubmitted }) => {
 				</>,
 				duration: 30,
 				style: {
-					height: "25vh",
+					height: "225px",
 					display: 'flex',
 					alignItems: 'center'
 				}


### PR DESCRIPTION
changed height variable to use 'px' instead of 'vh'. This allowed the notification to stay a consistent height no matter the screen size.