### PR TITLE
APPTRACK-1662 - Create logs for incident of users being exited without opportunity to extend session

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -43,6 +43,7 @@ import TimeoutModal from './components/TimeoutModal/TimeoutModal';
 import { COMMITTEE_MEMBER_ROLE } from './constants/Roles';
 import { checkAuth } from './constants/checkAuth';
 import useAuth from './hooks/useAuth';
+import { transformDateTimeToDisplay } from './components/Util/Date/Date';
 
 const app = () => {
 	const [isLoading, setIsLoading] = useState(true);
@@ -54,6 +55,10 @@ const app = () => {
 
 	let routes = [];
 	const { isUserLoggedIn, user } = auth;
+
+	if (user && isUserLoggedIn) {
+		console.log(`User: ${user.uid} Time: ${transformDateTimeToDisplay(new Date())}  Action: 'Session start'`);
+	}
 
 	if (isUserLoggedIn) {
 		if (user.isChair) {

--- a/src/components/TimeoutModal/TimeoutModal.js
+++ b/src/components/TimeoutModal/TimeoutModal.js
@@ -3,10 +3,12 @@ import axios from 'axios';
 import { CHECK_AUTH } from '../../constants/ApiEndpoints';
 import useAuth from '../../hooks/useAuth';
 import useTimeout from '../../hooks/useTimeout';
+import { transformDateTimeToDisplay } from '../../components/Util/Date/Date';
 import { Modal, Typography, Button } from 'antd';
 const { Paragraph } = Typography;
 
 const TimeoutModal = () => {
+
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const { auth, setAuth } = useAuth();
 	const { setModalTimeout } = useTimeout();
@@ -21,11 +23,17 @@ const TimeoutModal = () => {
 			timeout = setTimeout(() => {
 				setIsModalOpen(true);
 				setModalTimeout(0);
+				if (auth.user && auth.isUserLoggedIn) {
+					console.log(`User: ${auth.user.uid} Time: ${transformDateTimeToDisplay(new Date())}  Action: 'TimeoutModal shown'`);
+				}
 			}, uiTimeout);
 		};
 		const autoCloseModal = () => {
 			timeout = setTimeout(() => {
 				// log user out
+				if (auth.user && auth.isUserLoggedIn) {
+					console.log(`User: ${auth.user.uid} Time: ${transformDateTimeToDisplay(new Date())}  Action: 'TimeoutModal autoclose'`);
+				}
 				setIsModalOpen(false);
 				setModalTimeout(auth.sessionTimeout * 0.1);
 				location.href = '/logout.do';
@@ -50,9 +58,15 @@ const TimeoutModal = () => {
 		// extend user session
 		refreshAuth();
 		setIsModalOpen(false);
+		if (auth.user && auth.isUserLoggedIn) {
+			console.log(`User: ${auth.user.uid} Time: ${transformDateTimeToDisplay(new Date())}  Action: 'Session extended'`);
+		}
 	};
 
 	const handleCancel = () => {
+		if (auth.user && auth.isUserLoggedIn) {
+			console.log(`User: ${auth.user.uid} Time: ${transformDateTimeToDisplay(new Date())}  Action: 'User logged out'`);
+		}
 		setIsModalOpen(false);
 		location.href = '/logout.do';
 	};


### PR DESCRIPTION
Closes ticket: https://tracker.nci.nih.gov/browse/APPTRACK-1662

Testing: Check console logs to ensure the messages show up.

Note: I noticed we have an autoclose feature on the timeout modal by which user is logged out unless they respond to the dialog options. So I wonder if user is experiencing this feature. It could be we show the dialog a bit early and give them more time to respond.

Also eventually console.logs will be moved to some other logging solution for better debugging options.