### PR TITLE
APPTRACK-1607 - 508 Compliance: Fix List Structure on Vacancy Details Tab

### DIFF
--- a/src/containers/CreateVacancy/Forms/FinalizeVacancy/FinalizeVacancy.js
+++ b/src/containers/CreateVacancy/Forms/FinalizeVacancy/FinalizeVacancy.js
@@ -210,14 +210,14 @@ const finalizeVacancy = (props) => {
 					{basicInfo.sacCode ? null : '! '}Organizational Code
 				</h2>
 				<ul>
-					<p className='ListItemTrue'>{basicInfo.sacCode}</p>
+					<li className='ListItemTrue'>{basicInfo.sacCode}</li>
 				</ul>
 				<h2 style={basicInfo.positionClassification ? null : { color: 'red' }}>
 					{basicInfo.positionClassification ? null : '! '}Position
 					Classification
 				</h2>
 				<ul>
-					<p className='ListItemTrue'>{basicInfo.positionClassification}</p>
+					<li className='ListItemTrue'>{basicInfo.positionClassification}</li>
 				</ul>
 				<div><h2>Personnel Action Tracking Solution (PATS) Initiator</h2>
 					<ul>
@@ -226,12 +226,12 @@ const finalizeVacancy = (props) => {
 								<LoadingOutlined style={{ fontSize: '2rem' }} />
 							</Space>
 						) : (
-							<p className='ListItemTrue'>
+							<li className='ListItemTrue'>
 								{getPackageInitiatorDisplayName(
 									basicInfo.appointmentPackageIndicator,
 									allPackageInitiators
 								)}
-							</p>
+							</li>
 						)}
 					</ul></div>
 			</div>


### PR DESCRIPTION
Closes [APPTRACK-1607](https://tracker.nci.nih.gov/browse/APPTRACK-1607)

Testing - 

1. Ensure the Vacancy Details page looks right.
2. Ensure the 508 warnings dont show up in the Axe Tool(Please refer to the image as a reference)


<img width="1050" alt="Screenshot 2025-01-08 at 4 41 03 PM" src="https://github.com/user-attachments/assets/9287ffd3-b68a-4cab-b266-ba22051a04e3" />

