### PR TITLE
APPTRACK-1787 Hide the Demographics Tab on the Profile Page

### DIFF
--- a/src/containers/Profile/ApplicantProfile.js
+++ b/src/containers/Profile/ApplicantProfile.js
@@ -14,10 +14,11 @@ const tabList = [
 		key: 'basicInfo',
 		tab: 'Basic Information',
 	},
-	{
-		key: 'demographics',
-		tab: 'Demographics (optional)',
-	},
+	// Hide demographics tab
+	// {
+	// 	key: 'demographics',
+	// 	tab: 'Demographics (optional)',
+	// },
 ];
 
 const ApplicantProfile = () => {


### PR DESCRIPTION

Closes [APPTRACK-1787](https://tracker.nci.nih.gov/browse/APPTRACK-1787)

Hiding demopgraphics tab in user profile page.


<img width="856" alt="Screenshot 2025-02-05 at 10 08 23 AM" src="https://github.com/user-attachments/assets/22a8f30f-ee46-4eaf-88e5-000baeda2e59" />
