### PR TITLE
Potential fix for code scanning alert no. 1: Storage of sensitive information in build artifact

### DIFF
--- a/webpack/webpack.dev.config.js
+++ b/webpack/webpack.dev.config.js
@@ -76,10 +76,7 @@ const cfg = {
 		new webpack.DefinePlugin({
 			'process.env.REACT_APP_USER': JSON.stringify(
 				servicenowConfig.REACT_APP_USER
-			),
-			'process.env.REACT_APP_PASSWORD': JSON.stringify(
-				servicenowConfig.REACT_APP_PASSWORD
-			),
+			)
 		}),
 	],
 };


### PR DESCRIPTION
Potential fix for [https://github.com/CBIIT/app-tracker/security/code-scanning/1](https://github.com/CBIIT/app-tracker/security/code-scanning/1)

To fix the problem, avoid including any sensitive environment variables (e.g., passwords, API keys, tokens, or anything else confidential) in the code delivered to the browser via `DefinePlugin`. Only non-sensitive, public values should be exposed in this way. The best solution is to remove `process.env.REACT_APP_PASSWORD` from the `DefinePlugin` configuration in `webpack/webpack.dev.config.js` on lines 80–82. Only include environment variables that are meant to be publicly available.

**Required changes in `webpack/webpack.dev.config.js`:**
- Remove the line that injects `process.env.REACT_APP_PASSWORD` into the bundle.
- Only inject `REACT_APP_USER` if it is non-sensitive, or otherwise review whether it also needs to be removed.

No new imports or additional code is needed, just the removal of the offending line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
