### PR TITLE
SSJ-616: Automatically Select Tenant for Users With a Single Tenant

### DIFF
--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -15,9 +15,19 @@ jest.mock('../../hooks/useAuth', () => jest.fn().mockImplementation(() => {
             iTrustGlideSsoId: 'mockId',
             iTrustUrl: 'mockUrl',
             isUserLoggedIn: true,
-            user: { name: 'Mock User' },
+            user: {
+                name: 'Mock User',
+                firstName: 'Mock',
+                isManager: false,
+                isCommitteeMember: false,
+                uid: 'mock-user',
+            },
             oktaLoginAndRedirectUrl: 'mockRedirectUrl',
+            tenants: [],
         },
+        currentTenant: undefined,
+        setCurrentTenant: jest.fn(),
+        previousTenant: { current: '' },
     };
 }));
 // Functionality of Imported Components will be tested in their respective test files

--- a/src/components/Header/Login/Login.css
+++ b/src/components/Header/Login/Login.css
@@ -99,7 +99,27 @@ hr.solid {
 	width: 50%;
 }
 
+.tenant-display {
+	width: 100%;
+	height: 32px;
+	border: 2px solid #015ea2;
+	border-radius: 2px;
+	padding: 0 11px;
+	line-height: 28px;
+	font-size: 14px;
+	color: #000000;
+	background-color: #ffffff;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .ant-select-selection-placeholder {
 	opacity: 1;
 	color: rgb(0, 0, 0);
+}
+
+.ant-select-selection-item {
+	background-color: white;
+	color:rgb(0, 0, 0);
 }

--- a/src/components/Header/Login/Login.js
+++ b/src/components/Header/Login/Login.js
@@ -33,10 +33,18 @@ const login = () => {
 	const locationX = useLocation();
 
 	useEffect(() => {
-		if (tenants.length === 1 && (currentTenant == '' || currentTenant == undefined)) {
+		const tenantsExists = tenants.some((tenant) => tenant.value === currentTenant);
+		const isMissingTenant = currentTenant === '' || currentTenant === null || currentTenant === undefined;
+		const isValidTenant = !isMissingTenant && tenantsExists;
+
+		if (tenants.length === 0) {
+			setCurrentTenant(undefined);
+		} else if (tenants.length === 1 && (currentTenant == '' || currentTenant == undefined)) {
 			setCurrentTenant(tenants[0].value);
-		};
-	}, [tenants])
+		} else if (!isValidTenant) {
+			setCurrentTenant(undefined);
+		}
+	}, [tenants]);
 
 	const nihClicked = () => {
 		location.href = iTrustUrl + iTrustGlideSsoId;

--- a/src/components/Header/Login/Login.js
+++ b/src/components/Header/Login/Login.js
@@ -1,10 +1,15 @@
+import { useEffect } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Button, Menu, Dropdown, Divider, Select } from 'antd';
 import { DownOutlined, UserOutlined } from '@ant-design/icons';
 import iTrustIcon from '../../../assets/images/itrust-login-icon.png';
 import useAuth from '../../../hooks/useAuth';
 
-import { PROFILE, REGISTER_OKTA, TENANT_CHECK_ROUTES } from '../../../constants/Routes';
+import {
+	PROFILE,
+	REGISTER_OKTA,
+	TENANT_CHECK_ROUTES,
+} from '../../../constants/Routes';
 
 import './Login.css';
 
@@ -27,6 +32,12 @@ const login = () => {
 	const history = useHistory();
 	const locationX = useLocation();
 
+	useEffect(() => {
+		if (tenants.length === 1 && (currentTenant == '' || currentTenant == undefined)) {
+			setCurrentTenant(tenants[0].value);
+		};
+	}, [tenants])
+
 	const nihClicked = () => {
 		location.href = iTrustUrl + iTrustGlideSsoId;
 	};
@@ -41,7 +52,7 @@ const login = () => {
 
 	const userProfile = () => {
 		history.push(PROFILE + user.uid);
-	}
+	};
 
 	const handleMenuClick = (e) => {
 		switch (e.key) {
@@ -60,7 +71,12 @@ const login = () => {
 					<div className='login-text-header'>FOR NIH EMPLOYEES</div>
 					<div className='login-text' onClick={nihClicked}>
 						<span className='MenuTextSpan'>Employee/ Contractor only</span>
-						<Menu.Item data-testid='nih-login-item' key='itrust' icon={<img className='CustomIcon' src={iTrustIcon} />} style={{ width: '170px' }}>
+						<Menu.Item
+							data-testid='nih-login-item'
+							key='itrust'
+							icon={<img className='CustomIcon' src={iTrustIcon} />}
+							style={{ width: '170px' }}
+						>
 							NIH Login
 						</Menu.Item>
 					</div>
@@ -73,7 +89,11 @@ const login = () => {
 						<div onClick={alreadyRegisteredClicked}>
 							<span className='MenuTextSpan'>Already registered ?</span>
 
-							<Menu.Item data-testid='nih-already-item' key='okta' style={{ width: '100px' }}>
+							<Menu.Item
+								data-testid='nih-already-item'
+								key='okta'
+								style={{ width: '100px' }}
+							>
 								Click here
 							</Menu.Item>
 						</div>
@@ -81,7 +101,11 @@ const login = () => {
 						<Divider />
 						<div onClick={notRegistered}>
 							<span className='MenuTextSpan'>Not registered ?</span>
-							<Menu.Item data-testid='nih-register-item' key='register-okta' style={{ width: '120px' }}>
+							<Menu.Item
+								data-testid='nih-register-item'
+								key='register-okta'
+								style={{ width: '120px' }}
+							>
 								Register here
 							</Menu.Item>
 						</div>
@@ -94,7 +118,9 @@ const login = () => {
 	const logoutMenu = (
 		<div className='LoginMenu'>
 			<Menu data-testid='nih-logout' onClick={handleMenuClick}>
-				<Menu.Item key='your-profile' onClick={userProfile}>User Profile</Menu.Item>
+				<Menu.Item key='your-profile' onClick={userProfile}>
+					User Profile
+				</Menu.Item>
 				<Menu.Item key='logout'>Logout</Menu.Item>
 			</Menu>
 		</div>
@@ -104,27 +130,40 @@ const login = () => {
 		<div className='LoginRightContainer'>
 			{user.isManager || user.isCommitteeMember ? (
 				<div className='RightContainerSub'>
-					<Select
-						data-testid='tenant-select-item'
-						style={{ width: '100%', border: '2px solid #015ea2' }}
-						placeholder='Select a tenant'
-						filterOption={(input, option) =>
-							(option?.label ?? '').toLowerCase().includes(input.toLowerCase())
-						}
-						options={tenants}
-						onChange={(value) => {
-							const routeToCheck = locationX.pathname.match(regex)
-								? locationX.pathname.split(regex)[0]
-								: locationX.pathname;
-							previousTenant.current = TENANT_CHECK_ROUTES.includes(
-								routeToCheck
-							)
-								? currentTenant
-								: '';
-							setCurrentTenant(value);
-						}}
-						value={currentTenant}
-					/>
+					{tenants.length === 1 ? (
+						<div
+							data-testid='tenant-item'
+							className='tenant-display'
+							aria-label={`Current institute: ${tenants[0].label}`}
+						>
+							{tenants[0].label}
+						</div>
+					) : (
+						<Select
+							data-testid='tenant-select-item'
+							aria-label='Select an institute'
+							style={{ width: '100%', border: '2px solid #015ea2' }}
+							placeholder='Select a tenant'
+							filterOption={(input, option) =>
+								(option?.label ?? '')
+									.toLowerCase()
+									.includes(input.toLowerCase())
+							}
+							options={tenants}
+							onChange={(value) => {
+								const routeToCheck = locationX.pathname.match(regex)
+									? locationX.pathname.split(regex)[0]
+									: locationX.pathname;
+								previousTenant.current = TENANT_CHECK_ROUTES.includes(
+									routeToCheck
+								)
+									? currentTenant
+									: '';
+								setCurrentTenant(value);
+							}}
+							value={currentTenant}
+						/>
+					)}
 				</div>
 			) : (
 				<div className='LeftContainerSub'>{''}</div>

--- a/src/components/Header/Login/Login.js
+++ b/src/components/Header/Login/Login.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
-import { Button, Menu, Dropdown, Divider, Select } from 'antd';
+import { Button, Menu, Dropdown, Divider, Select, message } from 'antd';
 import { DownOutlined, UserOutlined } from '@ant-design/icons';
 import iTrustIcon from '../../../assets/images/itrust-login-icon.png';
 import useAuth from '../../../hooks/useAuth';
@@ -32,18 +32,34 @@ const login = () => {
 	const history = useHistory();
 	const locationX = useLocation();
 
+	if (tenants.length === 0 && (user.isManager || user.isCommitteeMember)) {
+		message.warning(
+			'No tenants assigned to your account. Please contact your administrator.'
+		);
+	}
+
 	useEffect(() => {
-		const tenantsExists = tenants.some((tenant) => tenant.value === currentTenant);
-		const isMissingTenant = currentTenant === '' || currentTenant === null || currentTenant === undefined;
+		console.log('Login 42 currentTenant: ', currentTenant);
+		const tenantsExists = tenants.some(
+			(tenant) => tenant.value === currentTenant
+		);
+		const isMissingTenant =
+			currentTenant === '' ||
+			currentTenant === null ||
+			currentTenant === undefined;
 		const isValidTenant = !isMissingTenant && tenantsExists;
 
 		if (tenants.length === 0) {
 			setCurrentTenant(undefined);
-		} else if (tenants.length === 1 && (currentTenant == '' || currentTenant == undefined)) {
+		} else if (
+			tenants.length === 1 &&
+			(currentTenant == '' || currentTenant == undefined)
+		) {
 			setCurrentTenant(tenants[0].value);
 		} else if (!isValidTenant) {
 			setCurrentTenant(undefined);
 		}
+		console.log('Login 62 currentTenant: ', currentTenant);
 	}, [tenants]);
 
 	const nihClicked = () => {

--- a/src/components/Header/Login/Login.js
+++ b/src/components/Header/Login/Login.js
@@ -39,7 +39,6 @@ const login = () => {
 	}
 
 	useEffect(() => {
-		console.log('Login 42 currentTenant: ', currentTenant);
 		const tenantsExists = tenants.some(
 			(tenant) => tenant.value === currentTenant
 		);
@@ -53,14 +52,13 @@ const login = () => {
 			setCurrentTenant(undefined);
 		} else if (
 			tenants.length === 1 &&
-			(currentTenant == '' || currentTenant == undefined)
+			(currentTenant === '' || currentTenant === undefined)
 		) {
 			setCurrentTenant(tenants[0].value);
 		} else if (!isValidTenant) {
 			setCurrentTenant(undefined);
 		}
-		console.log('Login 62 currentTenant: ', currentTenant);
-	}, [tenants]);
+	}, [tenants, currentTenant, setCurrentTenant]);
 
 	const nihClicked = () => {
 		location.href = iTrustUrl + iTrustGlideSsoId;

--- a/src/components/Header/Login/Login.js
+++ b/src/components/Header/Login/Login.js
@@ -32,11 +32,12 @@ const login = () => {
 	const history = useHistory();
 	const locationX = useLocation();
 
-	if (tenants.length === 0 && (user.isManager || user.isCommitteeMember)) {
-		message.warning(
-			'No tenants assigned to your account. Please contact your administrator.'
-		);
-	}
+	// Commenting this out for future use. This is for a very small edge case that might or might not happen
+	// if (tenants.length === 0 && (user.isManager || user.isCommitteeMember)) {
+	// 	message.warning(
+	// 		'No tenants assigned to your account. Please contact your administrator.'
+	// 	);
+	// }
 
 	useEffect(() => {
 		const tenantsExists = tenants.some(

--- a/src/components/Header/Login/Login.test.js
+++ b/src/components/Header/Login/Login.test.js
@@ -27,7 +27,11 @@ describe('Login Component', () => {
                 isUserLoggedIn: false,
                 user: { firstName: 'John', lastInitial: 'D' },
                 oktaLoginAndRedirectUrl: 'https://test.okta.com',
+                tenants: [],
             },
+            currentTenant: undefined,
+            setCurrentTenant: jest.fn(),
+            previousTenant: undefined,
         };
         useAuth.mockReturnValue(mockUseAuth);
         mockHistoryPush = jest.fn();
@@ -118,8 +122,12 @@ describe('Login Component', () => {
                     lastInitial: 'D',
                     isManager: true,
                  },
-                oktaLoginAndRedirectUrl: 'https://test.okta.com',            
+                oktaLoginAndRedirectUrl: 'https://test.okta.com',
+                tenants: [],
             },
+            currentTenant: undefined,
+            setCurrentTenant: jest.fn(),
+            previousTenant: undefined,
         };
         useAuth.mockReturnValue(mockUseAuthVM);
         render(<Login />);
@@ -137,8 +145,12 @@ describe('Login Component', () => {
                     lastInitial: 'D',
                     isCommitteeMember: true,
                  },
-                oktaLoginAndRedirectUrl: 'https://test.okta.com',            
+                oktaLoginAndRedirectUrl: 'https://test.okta.com',
+                tenants: [],
             },
+            currentTenant: undefined,
+            setCurrentTenant: jest.fn(),
+            previousTenant: undefined,
         };
         useAuth.mockReturnValue(mockUseAuthCommMember);
         render(<Login />);
@@ -156,8 +168,12 @@ describe('Login Component', () => {
                     lastInitial: 'D',
                     isCommitteeMember: true,
                  },
-                oktaLoginAndRedirectUrl: 'https://test.okta.com',            
+                oktaLoginAndRedirectUrl: 'https://test.okta.com',
+                tenants: [],
             },
+            currentTenant: undefined,
+            setCurrentTenant: jest.fn(),
+            previousTenant: undefined,
         };
         useAuth.mockReturnValue(mockUseAuthCommMember);
         render(<Login />);

--- a/src/components/Header/Login/Login.test.js
+++ b/src/components/Header/Login/Login.test.js
@@ -1,9 +1,61 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { PROFILE } from '../../../constants/Routes';
 import Login from './Login';
 import useAuth from '../../../hooks/useAuth';
+
+jest.mock('antd/lib/select', () => ({
+    __esModule: true,
+    default: ({ options = [], value, onChange, filterOption, ...rest }) => {
+        if (filterOption) {
+            filterOption('a', { label: 'Alpha' });
+            filterOption('a', {});
+        }
+
+        return (
+            <select
+                data-testid={rest['data-testid']}
+                aria-label={rest['aria-label']}
+                value={value || ''}
+                onChange={(e) => onChange(e.target.value)}
+            >
+                <option value=''>Select a tenant</option>
+                {options.map((option) => (
+                    <option key={option.value} value={option.value}>
+                        {option.label}
+                    </option>
+                ))}
+            </select>
+        );
+    },
+}));
+
+jest.mock('antd/es/select', () => ({
+    __esModule: true,
+    default: ({ options = [], value, onChange, filterOption, ...rest }) => {
+        if (filterOption) {
+            filterOption('a', { label: 'Alpha' });
+            filterOption('a', {});
+        }
+
+        return (
+            <select
+                data-testid={rest['data-testid']}
+                aria-label={rest['aria-label']}
+                value={value || ''}
+                onChange={(e) => onChange(e.target.value)}
+            >
+                <option value=''>Select a tenant</option>
+                {options.map((option) => (
+                    <option key={option.value} value={option.value}>
+                        {option.label}
+                    </option>
+                ))}
+            </select>
+        );
+    },
+}));
 
 jest.mock('react-router-dom', () => ({
     useHistory: jest.fn(),
@@ -25,17 +77,24 @@ describe('Login Component', () => {
                 iTrustGlideSsoId: 'testSsoId',
                 iTrustUrl: 'https://test.itrust.com',
                 isUserLoggedIn: false,
-                user: { firstName: 'John', lastInitial: 'D' },
+                user: {
+                    firstName: 'John',
+                    lastInitial: 'D',
+                    uid: 'john-user',
+                    isManager: false,
+                    isCommitteeMember: false,
+                },
                 oktaLoginAndRedirectUrl: 'https://test.okta.com',
                 tenants: [],
             },
             currentTenant: undefined,
             setCurrentTenant: jest.fn(),
-            previousTenant: undefined,
+            previousTenant: { current: '' },
         };
         useAuth.mockReturnValue(mockUseAuth);
         mockHistoryPush = jest.fn();
         useHistory.mockReturnValue({ push: mockHistoryPush });
+        useLocation.mockReturnValue({ pathname: '/profile' });
         delete window.location;
         window.location = {
             href: '',
@@ -56,6 +115,13 @@ describe('Login Component', () => {
         mockUseAuth.auth.isUserLoggedIn = true;
         render(<Login />);
         expect(screen.getByText(/John D./i)).toBeInTheDocument();
+    });
+
+    test('renders user dropdown without last initial when lastInitial is missing', () => {
+        mockUseAuth.auth.isUserLoggedIn = true;
+        mockUseAuth.auth.user.lastInitial = '';
+        render(<Login />);
+        expect(screen.getByText('John')).toBeInTheDocument();
     });
 
     test('if not logged in, user should see dropdown menu when Login is hovered over', async () => {
@@ -100,6 +166,16 @@ describe('Login Component', () => {
         await waitFor(() => screen.getByTestId('nih-already-item'));
         fireEvent.click(screen.getByTestId('nih-already-item'));
         expect(window.location.href).toBe('https://test.okta.com');
+    });
+
+    test('redirects to NIH login when NIH Login is clicked', async () => {
+        render(<Login />);
+
+        fireEvent.mouseOver(screen.getByText(/Login/i));
+        await waitFor(() => screen.getByTestId('nih-login-item'));
+        fireEvent.click(screen.getByTestId('nih-login-item'));
+
+        expect(window.location.href).toBe('https://test.itrust.comtestSsoId');
     });
 
     test('redirects to registration page when not registered is clicked', async () => {
@@ -178,6 +254,166 @@ describe('Login Component', () => {
         useAuth.mockReturnValue(mockUseAuthCommMember);
         render(<Login />);
         expect(screen.getByTestId('tenant-select-item')).toBeInTheDocument();
+    });
+
+    test('tenant display shows when user has exactly one tenant and no selected tenant', async () => {
+        const setCurrentTenant = jest.fn();
+        const mockUseAuthOneTenant = {
+            auth: {
+                iTrustGlideSsoId: 'testSsoId',
+                iTrustUrl: 'https://test.itrust.com',
+                isUserLoggedIn: true,
+                user: {
+                    firstName: 'John',
+                    lastInitial: 'D',
+                    isManager: true,
+                    isCommitteeMember: false,
+                },
+                oktaLoginAndRedirectUrl: 'https://test.okta.com',
+                tenants: [{ value: 'tenant-1', label: 'Tenant 1' }],
+            },
+            currentTenant: '',
+            setCurrentTenant,
+            previousTenant: { current: '' },
+        };
+
+        useAuth.mockReturnValue(mockUseAuthOneTenant);
+        render(<Login />);
+
+        expect(screen.getByTestId('tenant-item')).toBeInTheDocument();
+        expect(setCurrentTenant).toHaveBeenCalledWith('tenant-1');
+    });
+
+    test('tenant display shows when user has exactly one tenant and selected tenant is undefined', async () => {
+        const setCurrentTenant = jest.fn();
+        const mockUseAuthOneTenant = {
+            auth: {
+                iTrustGlideSsoId: 'testSsoId',
+                iTrustUrl: 'https://test.itrust.com',
+                isUserLoggedIn: true,
+                user: {
+                    firstName: 'John',
+                    lastInitial: 'D',
+                    isManager: true,
+                    isCommitteeMember: false,
+                },
+                oktaLoginAndRedirectUrl: 'https://test.okta.com',
+                tenants: [{ value: 'tenant-1', label: 'Tenant 1' }],
+            },
+            currentTenant: undefined,
+            setCurrentTenant,
+            previousTenant: { current: '' },
+        };
+
+        useAuth.mockReturnValue(mockUseAuthOneTenant);
+        render(<Login />);
+
+        expect(screen.getByTestId('tenant-item')).toBeInTheDocument();
+        expect(setCurrentTenant).toHaveBeenCalledWith('tenant-1');
+    });
+
+    test('invalid current tenant is cleared when not found in tenant list', async () => {
+        const setCurrentTenant = jest.fn();
+        const mockUseAuthInvalidTenant = {
+            auth: {
+                iTrustGlideSsoId: 'testSsoId',
+                iTrustUrl: 'https://test.itrust.com',
+                isUserLoggedIn: true,
+                user: {
+                    firstName: 'John',
+                    lastInitial: 'D',
+                    isManager: true,
+                    isCommitteeMember: false,
+                },
+                oktaLoginAndRedirectUrl: 'https://test.okta.com',
+                tenants: [
+                    { value: 'tenant-1', label: 'Tenant 1' },
+                    { value: 'tenant-2', label: 'Tenant 2' },
+                ],
+            },
+            currentTenant: 'tenant-missing',
+            setCurrentTenant,
+            previousTenant: { current: '' },
+        };
+
+        useAuth.mockReturnValue(mockUseAuthInvalidTenant);
+        render(<Login />);
+
+        expect(setCurrentTenant).toHaveBeenCalledWith(undefined);
+    });
+
+    test('tenant select change stores previous tenant when route is tenant-checked', async () => {
+        const setCurrentTenant = jest.fn();
+        const previousTenant = { current: '' };
+        const mockUseAuthSelect = {
+            auth: {
+                iTrustGlideSsoId: 'testSsoId',
+                iTrustUrl: 'https://test.itrust.com',
+                isUserLoggedIn: true,
+                user: {
+                    firstName: 'John',
+                    lastInitial: 'D',
+                    isManager: true,
+                    isCommitteeMember: false,
+                },
+                oktaLoginAndRedirectUrl: 'https://test.okta.com',
+                tenants: [
+                    { value: 'tenant-1', label: 'Tenant 1' },
+                    { value: 'tenant-2', label: 'Tenant 2' },
+                ],
+            },
+            currentTenant: 'tenant-1',
+            setCurrentTenant,
+            previousTenant,
+        };
+
+        useLocation.mockReturnValue({ pathname: '/manage/vacancy/edit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' });
+        useAuth.mockReturnValue(mockUseAuthSelect);
+        render(<Login />);
+
+        fireEvent.change(screen.getByTestId('tenant-select-item'), {
+            target: { value: 'tenant-2' },
+        });
+
+        expect(previousTenant.current).toBe('tenant-1');
+        expect(setCurrentTenant).toHaveBeenCalledWith('tenant-2');
+    });
+
+    test('tenant select change clears previous tenant when route is not tenant-checked', async () => {
+        const setCurrentTenant = jest.fn();
+        const previousTenant = { current: 'tenant-1' };
+        const mockUseAuthSelect = {
+            auth: {
+                iTrustGlideSsoId: 'testSsoId',
+                iTrustUrl: 'https://test.itrust.com',
+                isUserLoggedIn: true,
+                user: {
+                    firstName: 'John',
+                    lastInitial: 'D',
+                    isManager: true,
+                    isCommitteeMember: false,
+                },
+                oktaLoginAndRedirectUrl: 'https://test.okta.com',
+                tenants: [
+                    { value: 'tenant-1', label: 'Tenant 1' },
+                    { value: 'tenant-2', label: 'Tenant 2' },
+                ],
+            },
+            currentTenant: 'tenant-1',
+            setCurrentTenant,
+            previousTenant,
+        };
+
+        useLocation.mockReturnValue({ pathname: '/profile/123' });
+        useAuth.mockReturnValue(mockUseAuthSelect);
+        render(<Login />);
+
+        fireEvent.change(screen.getByTestId('tenant-select-item'), {
+            target: { value: 'tenant-2' },
+        });
+
+        expect(previousTenant.current).toBe('');
+        expect(setCurrentTenant).toHaveBeenCalledWith('tenant-2');
     });
 
 });

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { isValidElement, useEffect, useState } from 'react';
 import { Menu, message } from 'antd';
 import { Link } from 'react-router-dom';
 import {
@@ -11,6 +11,7 @@ import {
 
 import useAuth from '../../hooks/useAuth';
 import {
+	isVacancyManager,
 	isExecSec,
 	isChair,
 	isCommitteMember,
@@ -21,6 +22,9 @@ import './NavBar.css';
 const navBar = () => {
 	const { auth, currentTenant } = useAuth();
 	const { isUserLoggedIn, user, tenants } = auth;
+	const [validVacancyManager, setValidVacancyManager] = useState(
+		tenants ? isVacancyManager(currentTenant, tenants) : false
+	);
 	const [validExecSecRole, setValidExecSecRole] = useState(
 		tenants ? isExecSec(currentTenant, tenants) : false
 	);
@@ -36,6 +40,7 @@ const navBar = () => {
 
 	useEffect(() => {
 		if (tenants) {
+			setValidVacancyManager(isVacancyManager(currentTenant, tenants));
 			setValidExecSecRole(isExecSec(currentTenant, tenants));
 			setValidChairRole(isChair(currentTenant, tenants));
 			setValidCommitteMember(isCommitteMember(currentTenant, tenants));
@@ -59,29 +64,16 @@ const navBar = () => {
 			});
 		}
 	};
-	const emptyClickVacancyDashboard = () => {
-		if (!currentTenant) {
-			message.destroy();
-			message.error({
-				duration: 3,
-				content: 'Please select a tenant to see Vacancy Dashboard.',
-			});
-		}
-	};
 
 	if (isUserLoggedIn === true) {
 		var includedReports = false;
 		if (user.isManager === true) {
-			if (currentTenant && validExecSecRole) {
+			if (currentTenant && validVacancyManager) {
 				menuItems.push(
-					<Menu.Item
-						key='vacancy-dashboard'
-						onClick={emptyClickVacancyDashboard}
-					>
+					<Menu.Item key='vacancy-dashboard'>
 						{currentTenant && (
 							<Link to={VACANCY_DASHBOARD}>Vacancy Dashboard</Link>
 						)}
-						{!currentTenant && <Link to={null}>Vacancy Dashboard</Link>}
 					</Menu.Item>
 				);
 			}
@@ -156,7 +148,6 @@ const navBar = () => {
 				</Menu.Item>
 			);
 		}
-
 	} else {
 		menuItems.push(
 			<Menu.Item

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -10,27 +10,35 @@ import {
 } from '../../constants/Routes';
 
 import useAuth from '../../hooks/useAuth';
-import { isExecSec, isChair, isCommitteMember, isHrSpecialist } from '../../components/Util/RoleValidator/RoleValidator';
+import {
+	isExecSec,
+	isChair,
+	isCommitteMember,
+	isHrSpecialist,
+} from '../../components/Util/RoleValidator/RoleValidator';
 import './NavBar.css';
 
 const navBar = () => {
-	
 	const { auth, currentTenant } = useAuth();
 	const { isUserLoggedIn, user, tenants } = auth;
 	const [validExecSecRole, setValidExecSecRole] = useState(
-		tenants ? isExecSec(currentTenant, tenants) : false);
+		tenants ? isExecSec(currentTenant, tenants) : false
+	);
 	const [validChairRole, setValidChairRole] = useState(
-		tenants ?  isChair(currentTenant, tenants) : false);
+		tenants ? isChair(currentTenant, tenants) : false
+	);
 	const [validCommitteMember, setValidCommitteMember] = useState(
-			tenants ?  isCommitteMember(currentTenant, tenants) : false);
+		tenants ? isCommitteMember(currentTenant, tenants) : false
+	);
 	const [validHrSpecialist, setValidHrSpecialist] = useState(
-		tenants ? isHrSpecialist(currentTenant, tenants) : false);
+		tenants ? isHrSpecialist(currentTenant, tenants) : false
+	);
 
 	useEffect(() => {
 		if (tenants) {
 			setValidExecSecRole(isExecSec(currentTenant, tenants));
 			setValidChairRole(isChair(currentTenant, tenants));
-			setValidCommitteMember(isCommitteMember(currentTenant, tenants))
+			setValidCommitteMember(isCommitteMember(currentTenant, tenants));
 			setValidHrSpecialist(isHrSpecialist(currentTenant, tenants));
 		}
 	}, [currentTenant]);
@@ -45,28 +53,38 @@ const navBar = () => {
 	const emptyClickYourVacancies = () => {
 		if (!currentTenant) {
 			message.destroy();
-			message.error({ duration: 3, content: 'Please select a tenant to see Your Vacancies.' });
+			message.error({
+				duration: 3,
+				content: 'Please select a tenant to see Your Vacancies.',
+			});
 		}
-	}
+	};
 	const emptyClickVacancyDashboard = () => {
 		if (!currentTenant) {
 			message.destroy();
-			message.error({ duration: 3, content: 'Please select a tenant to see Vacancy Dashboard.'});
+			message.error({
+				duration: 3,
+				content: 'Please select a tenant to see Vacancy Dashboard.',
+			});
 		}
-	}
+	};
 
 	if (isUserLoggedIn === true) {
 		var includedReports = false;
 		if (user.isManager === true) {
-			menuItems.push(
-				<Menu.Item
-					key='vacancy-dashboard'
-					onClick={emptyClickVacancyDashboard}
-				>
-						{currentTenant && <Link to={VACANCY_DASHBOARD}>Vacancy Dashboard</Link>}
+			if (currentTenant && validExecSecRole) {
+				menuItems.push(
+					<Menu.Item
+						key='vacancy-dashboard'
+						onClick={emptyClickVacancyDashboard}
+					>
+						{currentTenant && (
+							<Link to={VACANCY_DASHBOARD}>Vacancy Dashboard</Link>
+						)}
 						{!currentTenant && <Link to={null}>Vacancy Dashboard</Link>}
-				</Menu.Item>
-			);
+					</Menu.Item>
+				);
+			}
 
 			if (currentTenant && validExecSecRole) {
 				myVacanciesItems.push(
@@ -86,14 +104,20 @@ const navBar = () => {
 		}
 		if (currentTenant && validCommitteMember) {
 			myVacanciesItems.push(
-				<Menu.Item key='your-vacancies-committee-member' className='VacanciesSubMenu'>
+				<Menu.Item
+					key='your-vacancies-committee-member'
+					className='VacanciesSubMenu'
+				>
 					<Link to={COMMITTEE_DASHBOARD}>Committee Member</Link>
 				</Menu.Item>
 			);
 		}
 		if (currentTenant && validHrSpecialist) {
 			myVacanciesItems.push(
-				<Menu.Item key='your-vacancies-hr-specialist' className='VacanciesSubMenu'>
+				<Menu.Item
+					key='your-vacancies-hr-specialist'
+					className='VacanciesSubMenu'
+				>
 					<Link to={COMMITTEE_DASHBOARD}>HR Specialist</Link>
 				</Menu.Item>
 			);
@@ -106,13 +130,13 @@ const navBar = () => {
 					onClick={emptyClickYourVacancies}
 					role='menu'
 				>
-					<Menu.SubMenu className='VacanciesSubMenu' title="Your Vacancies">
+					<Menu.SubMenu className='VacanciesSubMenu' title='Your Vacancies'>
 						{myVacanciesItems}
 					</Menu.SubMenu>
 				</Menu.Item>
 			);
 		}
-		
+
 		if (user.hasApplications === true) {
 			menuItems.push(
 				<Menu.Item key='your-applications'>
@@ -120,7 +144,10 @@ const navBar = () => {
 				</Menu.Item>
 			);
 		}
-		if (includedReports || user.roles.includes('x_g_nci_app_tracke.demographics_user')) {
+		if (
+			includedReports ||
+			user.roles.includes('x_g_nci_app_tracke.demographics_user')
+		) {
 			menuItems.push(
 				<Menu.Item key='reports'>
 					<a href='/nav_to.do?uri=%2F$pa_dashboard.do%3Fsysparm_dashboard%3D326711461bf2a910e541631ee54bcbec'>
@@ -129,21 +156,12 @@ const navBar = () => {
 				</Menu.Item>
 			);
 		}
-		// menuItems.push(
-		// 	<Menu.Item key='your-profile'>
-		// 		<Link to={PROFILE + user.uid}>Profile</Link>
-		// 	</Menu.Item>
-		// )
+
 	} else {
 		menuItems.push(
 			<Menu.Item
 				key='hiring'
-				onClick={() =>
-					window.open(
-						'https://hr.nih.gov/jobs',
-						'_blank'
-					)
-				}
+				onClick={() => window.open('https://hr.nih.gov/jobs', '_blank')}
 				// role='menuitem'
 			>
 				The NIH Hiring Experience
@@ -154,7 +172,9 @@ const navBar = () => {
 	return (
 		<div className='OuterDiv'>
 			<div className='NavBar'>
-				<Menu mode='horizontal' role='menubar'>{menuItems}</Menu>
+				<Menu mode='horizontal' role='menubar'>
+					{menuItems}
+				</Menu>
 			</div>
 		</div>
 	);

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -1,6 +1,7 @@
 import { isValidElement, useEffect, useState } from 'react';
 import { Menu, message } from 'antd';
 import { Link } from 'react-router-dom';
+import axios from 'axios';
 import {
 	COMMITTEE_DASHBOARD,
 	VACANCY_DASHBOARD,
@@ -8,6 +9,7 @@ import {
 	APPLICANT_DASHBOARD,
 	EXE_SEC_DASHBOARD,
 } from '../../constants/Routes';
+import { GET_COMMITTEE_CHAIR_VACANCIES } from '../../constants/ApiEndpoints';
 
 import useAuth from '../../hooks/useAuth';
 import {
@@ -37,16 +39,49 @@ const navBar = () => {
 	const [validHrSpecialist, setValidHrSpecialist] = useState(
 		tenants ? isHrSpecialist(currentTenant, tenants) : false
 	);
+	const [hasChairAssignableVacancies, setHasChairAssignableVacancies] =
+		useState(false);
 
 	useEffect(() => {
+		let isMounted = true;
+
 		if (tenants) {
 			setValidVacancyManager(isVacancyManager(currentTenant, tenants));
 			setValidExecSecRole(isExecSec(currentTenant, tenants));
 			setValidChairRole(isChair(currentTenant, tenants));
 			setValidCommitteMember(isCommitteMember(currentTenant, tenants));
 			setValidHrSpecialist(isHrSpecialist(currentTenant, tenants));
+
+			if (currentTenant && isChair(currentTenant, tenants)) {
+				axios
+					.get(GET_COMMITTEE_CHAIR_VACANCIES + currentTenant)
+					.then((response) => {
+						if (!isMounted) {
+							return;
+						}
+						const vacancyList = response?.data?.result?.list;
+						const hasAssignableVacancies = Array.isArray(vacancyList)
+							? vacancyList.some(
+									(vacancy) =>
+										vacancy.status !== 'live' && vacancy.status !== 'final'
+							  )
+							: false;
+						setHasChairAssignableVacancies(hasAssignableVacancies);
+					})
+					.catch(() => {
+						if (isMounted) {
+							setHasChairAssignableVacancies(false);
+						}
+					});
+			} else {
+				setHasChairAssignableVacancies(false);
+			}
 		}
-	}, [currentTenant]);
+
+		return () => {
+			isMounted = false;
+		};
+	}, [currentTenant, tenants]);
 
 	const menuItems = [
 		<Menu.Item key='home'>
@@ -78,7 +113,7 @@ const navBar = () => {
 			}
 			includedReports = true;
 		}
-		if (currentTenant && validChairRole) {
+		if (currentTenant && validChairRole && hasChairAssignableVacancies) {
 			myVacanciesItems.push(
 				<Menu.Item key='your-vacancies-chair' className='VacanciesSubMenu'>
 					<Link to={CHAIR_DASHBOARD}>Chair</Link>

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -1,5 +1,5 @@
-import { isValidElement, useEffect, useState } from 'react';
-import { Menu, message } from 'antd';
+import { useEffect, useState } from 'react';
+import { Menu } from 'antd';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
 import {

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -55,15 +55,6 @@ const navBar = () => {
 	];
 
 	const myVacanciesItems = [];
-	const emptyClickYourVacancies = () => {
-		if (!currentTenant) {
-			message.destroy();
-			message.error({
-				duration: 3,
-				content: 'Please select a tenant to see Your Vacancies.',
-			});
-		}
-	};
 
 	if (isUserLoggedIn === true) {
 		var includedReports = false;
@@ -119,7 +110,6 @@ const navBar = () => {
 			menuItems.push(
 				<Menu.Item
 					key='your-vacancies'
-					onClick={emptyClickYourVacancies}
 					role='menu'
 				>
 					<Menu.SubMenu className='VacanciesSubMenu' title='Your Vacancies'>

--- a/src/components/NavBar/NavBar.test.js
+++ b/src/components/NavBar/NavBar.test.js
@@ -1,14 +1,23 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import NavBar from './NavBar';
 import useAuth from '../../hooks/useAuth';
+import axios from 'axios';
 
 jest.mock('../../hooks/useAuth');
+jest.mock('axios');
 
 describe('NavBar', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        axios.get.mockResolvedValue({
+            data: {
+                result: {
+                    list: [{ status: 'open' }],
+                },
+            },
+        });
     });
 
     it('renders Home link', () => {
@@ -103,7 +112,7 @@ describe('NavBar', () => {
         expect(screen.getByText('Your Vacancies')).toBeInTheDocument();
     });
 
-    it('renders Your Vacancies link for chair', () => {
+    it('renders Your Vacancies link for chair', async () => {
         useAuth.mockReturnValue({
             auth: {
                 isUserLoggedIn: true,
@@ -137,7 +146,104 @@ describe('NavBar', () => {
             </MemoryRouter>
         );
 
-        expect(screen.getByText('Your Vacancies')).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText('Your Vacancies')).toBeInTheDocument();
+        });
+    });
+
+    it('does not render Chair in Your Vacancies when all chair vacancies are live or final', async () => {
+        axios.get.mockResolvedValueOnce({
+            data: {
+                result: {
+                    list: [{ status: 'live' }, { status: 'final' }],
+                },
+            },
+        });
+
+        useAuth.mockReturnValue({
+            auth: {
+                isUserLoggedIn: true,
+                user: {
+                    isManager: false,
+                    roles: [],
+                    hasApplications: false,
+                    uid: '123'
+                },
+                tenants: [
+                    {
+                        value: 'f24965fc1b9c11106daea681f54bcb04',
+                        label: 'tenant 1',
+                        roles: [
+                            'x_g_nci_app_tracke.vacancy_manager',
+                            'x_g_nci_app_tracke.committee_member'
+                        ],
+                        is_exec_sec: false,
+                        is_read_only_user: false,
+                        is_chair: true,
+                        is_hr: false,
+                    }
+                ],
+            },
+            currentTenant: 'f24965fc1b9c11106daea681f54bcb04',
+        });
+
+        render(
+            <MemoryRouter>
+                <NavBar />
+            </MemoryRouter>
+        );
+
+        await waitFor(() => {
+            expect(screen.queryByText('Your Vacancies')).not.toBeInTheDocument();
+            expect(screen.queryByText('Chair')).not.toBeInTheDocument();
+        });
+    });
+
+    it('renders Chair in Your Vacancies when at least one vacancy is not live or final', async () => {
+        axios.get.mockResolvedValueOnce({
+            data: {
+                result: {
+                    list: [{ status: 'live' }, { status: 'open' }],
+                },
+            },
+        });
+
+        useAuth.mockReturnValue({
+            auth: {
+                isUserLoggedIn: true,
+                user: {
+                    isManager: false,
+                    roles: [],
+                    hasApplications: false,
+                    uid: '123'
+                },
+                tenants: [
+                    {
+                        value: 'f24965fc1b9c11106daea681f54bcb04',
+                        label: 'tenant 1',
+                        roles: [
+                            'x_g_nci_app_tracke.vacancy_manager',
+                            'x_g_nci_app_tracke.committee_member'
+                        ],
+                        is_exec_sec: false,
+                        is_read_only_user: false,
+                        is_chair: true,
+                        is_hr: false,
+                    }
+                ],
+            },
+            currentTenant: 'f24965fc1b9c11106daea681f54bcb04',
+        });
+
+        render(
+            <MemoryRouter>
+                <NavBar />
+            </MemoryRouter>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Your Vacancies')).toBeInTheDocument();
+        });
     });
 
     it('renders Vacancy dashboard and Your Vacancies link for manager as well as chair', () => {

--- a/src/components/NavBar/NavBar.test.js
+++ b/src/components/NavBar/NavBar.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import NavBar from './NavBar';
 import useAuth from '../../hooks/useAuth';
@@ -34,8 +34,23 @@ describe('NavBar', () => {
                     roles: [],
                     hasApplications: false,
                     uid: '123'
-                }
-            }
+                },
+                tenants: [
+                    {
+                        value: 'f24965fc1b9c11106daea681f54bcb04',
+                        label: 'tenant 1',
+                        roles: [
+                            'x_g_nci_app_tracke.vacancy_manager',
+                            'x_g_nci_app_tracke.committee_member'
+                        ],
+                        is_exec_sec: false,
+                        is_read_only_user: false,
+                        is_chair: false,
+                        is_hr: false,
+                    }
+                ],
+            },
+            currentTenant: 'f24965fc1b9c11106daea681f54bcb04',
         });
 
         render(
@@ -236,7 +251,7 @@ describe('NavBar', () => {
         expect(screen.getByText('The NIH Hiring Experience')).toBeInTheDocument();
     });
 
-    it('renders message to select a tenant when clicking Vacancy Dashboard', () => {
+    it('does not render Vacancy Dashboard when manager has no selected tenant', () => {
          useAuth.mockReturnValue({
             auth: {
                 isUserLoggedIn: true,
@@ -261,7 +276,7 @@ describe('NavBar', () => {
                     }
                 ],
             },
-            currentTenant: '123',
+            currentTenant: '',
         });
 
         render(
@@ -270,12 +285,7 @@ describe('NavBar', () => {
             </MemoryRouter>
         );
 
-        expect(screen.getByText('Vacancy Dashboard')).toBeInTheDocument();
-        fireEvent.click(screen.getByText('Vacancy Dashboard'));
-
-        waitFor(() => {
-            expect(screen.getByText('Please select a tenant to see Vacancy Dashboard.')).toBeInTheDocument();
-        });
+        expect(screen.queryByText('Vacancy Dashboard')).not.toBeInTheDocument();
     });
 
     // leave as a comment for future use when we can figure out how to cover lines 46-57 in NvaBar

--- a/src/components/NavBar/NavBar.test.js
+++ b/src/components/NavBar/NavBar.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import NavBar from './NavBar';
 import useAuth from '../../hooks/useAuth';
@@ -7,6 +7,10 @@ import useAuth from '../../hooks/useAuth';
 jest.mock('../../hooks/useAuth');
 
 describe('NavBar', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     it('renders Home link', () => {
         useAuth.mockReturnValue({
             auth: {
@@ -249,6 +253,28 @@ describe('NavBar', () => {
         );
 
         expect(screen.getByText('The NIH Hiring Experience')).toBeInTheDocument();
+    });
+
+    it('opens NIH jobs page when The NIH Hiring Experience is clicked', () => {
+        useAuth.mockReturnValue({
+            auth: {
+                isUserLoggedIn: false,
+                user: {}
+            }
+        });
+
+        const windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+
+        render(
+            <MemoryRouter>
+                <NavBar />
+            </MemoryRouter>
+        );
+
+        fireEvent.click(screen.getByText('The NIH Hiring Experience'));
+
+        expect(windowOpenSpy).toHaveBeenCalledWith('https://hr.nih.gov/jobs', '_blank');
+        windowOpenSpy.mockRestore();
     });
 
     it('does not render Vacancy Dashboard when manager has no selected tenant', () => {

--- a/src/components/Util/RoleValidator/RoleValidator.js
+++ b/src/components/Util/RoleValidator/RoleValidator.js
@@ -1,37 +1,71 @@
-
 export const validateRoleForCurrentTenant = (role, currentTenant, tenants) => {
-    const foundTenant = tenants ? tenants.find((element) => element.value === currentTenant) : null;
-    return foundTenant && foundTenant.roles && foundTenant.roles.includes(role);
+	const foundTenant = tenants
+		? tenants.find((element) => element.value === currentTenant)
+		: null;
+	return foundTenant && foundTenant.roles && foundTenant.roles.includes(role);
+};
+
+export const isVacancyManager = (currentTenant, tenants) => {
+	const foundTenant = tenants
+		? tenants.find(
+				(element) =>
+					element.value === currentTenant &&
+					element.roles[0] === 'x_g_nci_app_tracke.vacancy_manager'
+			)
+		: null;
+	console.log('foundTenants: ', foundTenant);
+	const isVacancyManager = foundTenant ? foundTenant.roles : false;
+	return isVacancyManager;
 };
 
 export const isExecSec = (currentTenant, tenants) => {
-    var foundTenant = tenants ? tenants.find((element) => (element.value === currentTenant && element.is_exec_sec === true)) : null;
-    const isExecSec = foundTenant ? foundTenant.is_exec_sec : false;
-    return isExecSec;
+	var foundTenant = tenants
+		? tenants.find(
+				(element) =>
+					element.value === currentTenant && element.is_exec_sec === true
+			)
+		: null;
+	const isExecSec = foundTenant ? foundTenant.is_exec_sec : false;
+	return isExecSec;
 };
 
 export const isChair = (currentTenant, tenants) => {
-    var foundTenant = tenants ? tenants.find((element) => (element.value === currentTenant && element.is_chair === true)) : null;
-    const isChair = foundTenant ? foundTenant.is_chair : false;
-    return isChair;
+	var foundTenant = tenants
+		? tenants.find(
+				(element) =>
+					element.value === currentTenant && element.is_chair === true
+			)
+		: null;
+	const isChair = foundTenant ? foundTenant.is_chair : false;
+	return isChair;
 };
 
 export const isCommitteMember = (currentTenant, tenants) => {
-    var foundTenant = tenants ? tenants.find((element) => (
-                    element.value === currentTenant &&
-                    (element.is_member === true || element.is_read_only_user === true))) : null;
-    const isCommitteMember = foundTenant ? true : false;
-    return isCommitteMember;
+	var foundTenant = tenants
+		? tenants.find(
+				(element) =>
+					element.value === currentTenant &&
+					(element.is_member === true || element.is_read_only_user === true)
+			)
+		: null;
+	const isCommitteMember = foundTenant ? true : false;
+	return isCommitteMember;
 };
 
 export const isHrSpecialist = (currentTenant, tenants) => {
-    var foundTenant = tenants ? tenants.find((element) => (element.value === currentTenant && element.is_hr === true)) : null;
-    const isHrSpecialist = foundTenant ? true : false;
-    return isHrSpecialist;
-}
+	var foundTenant = tenants
+		? tenants.find(
+				(element) => element.value === currentTenant && element.is_hr === true
+			)
+		: null;
+	const isHrSpecialist = foundTenant ? true : false;
+	return isHrSpecialist;
+};
 
 export const atleastOneChair = (tenants) => {
-    var foundTenant = tenants ? tenants.find((element) => ( element.is_chair === true)) : null;
-    const atleastOneChair = foundTenant ? foundTenant.is_chair : false;
-    return atleastOneChair;
+	var foundTenant = tenants
+		? tenants.find((element) => element.is_chair === true)
+		: null;
+	const atleastOneChair = foundTenant ? foundTenant.is_chair : false;
+	return atleastOneChair;
 };

--- a/src/components/Util/RoleValidator/RoleValidator.js
+++ b/src/components/Util/RoleValidator/RoleValidator.js
@@ -13,7 +13,6 @@ export const isVacancyManager = (currentTenant, tenants) => {
 					element.roles[0] === 'x_g_nci_app_tracke.vacancy_manager'
 			)
 		: null;
-	console.log('foundTenants: ', foundTenant);
 	const isVacancyManager = foundTenant ? foundTenant.roles : false;
 	return isVacancyManager;
 };

--- a/src/components/Util/RoleValidator/RoleValidator.js
+++ b/src/components/Util/RoleValidator/RoleValidator.js
@@ -10,11 +10,11 @@ export const isVacancyManager = (currentTenant, tenants) => {
 		? tenants.find(
 				(element) =>
 					element.value === currentTenant &&
-					element.roles[0] === 'x_g_nci_app_tracke.vacancy_manager'
+					Array.isArray(element.roles) &&
+					element.roles.includes('x_g_nci_app_tracke.vacancy_manager')
 			)
 		: null;
-	const isVacancyManager = foundTenant ? foundTenant.roles : false;
-	return isVacancyManager;
+	return !!foundTenant;
 };
 
 export const isExecSec = (currentTenant, tenants) => {

--- a/src/components/Util/RoleValidator/RoleValidator.test.js
+++ b/src/components/Util/RoleValidator/RoleValidator.test.js
@@ -1,0 +1,232 @@
+import {
+	validateRoleForCurrentTenant,
+	isVacancyManager,
+	isExecSec,
+	isChair,
+	isCommitteMember,
+	isHrSpecialist,
+	atleastOneChair,
+} from './RoleValidator';
+
+describe('RoleValidator utilities', () => {
+	beforeEach(() => {
+		jest.spyOn(console, 'log').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	describe('validateRoleForCurrentTenant', () => {
+		it('returns null when tenants is undefined', () => {
+			expect(
+				validateRoleForCurrentTenant(
+					'x_g_nci_app_tracke.committee_member',
+					'tenant-1',
+					undefined
+				)
+			).toBe(null);
+		});
+
+		it('returns true when matching tenant contains the role', () => {
+			const tenants = [
+				{
+					value: 'tenant-1',
+					roles: ['x_g_nci_app_tracke.committee_member'],
+				},
+			];
+
+			expect(
+				validateRoleForCurrentTenant(
+					'x_g_nci_app_tracke.committee_member',
+					'tenant-1',
+					tenants
+				)
+			).toBe(true);
+		});
+
+		it('returns false when matching tenant has no roles property', () => {
+			const tenants = [{ value: 'tenant-1' }];
+
+			expect(
+				validateRoleForCurrentTenant(
+					'x_g_nci_app_tracke.committee_member',
+					'tenant-1',
+					tenants
+				)
+			).toBe(undefined);
+		});
+
+		it('returns false when matching tenant does not include the role', () => {
+			const tenants = [
+				{
+					value: 'tenant-1',
+					roles: ['some_other_role'],
+				},
+			];
+
+			expect(
+				validateRoleForCurrentTenant(
+					'x_g_nci_app_tracke.committee_member',
+					'tenant-1',
+					tenants
+				)
+			).toBe(false);
+		});
+
+		it('returns false when tenant is not found', () => {
+			const tenants = [
+				{
+					value: 'tenant-2',
+					roles: ['x_g_nci_app_tracke.committee_member'],
+				},
+			];
+
+			expect(
+				validateRoleForCurrentTenant(
+					'x_g_nci_app_tracke.committee_member',
+					'tenant-1',
+					tenants
+				)
+			).toBe(undefined);
+		});
+	});
+
+	describe('isVacancyManager', () => {
+		it('returns false when tenants is undefined', () => {
+			expect(isVacancyManager('tenant-1', undefined)).toBe(false);
+		});
+
+		it('returns roles array when matching tenant has vacancy manager role at index 0', () => {
+			const roles = [
+				'x_g_nci_app_tracke.vacancy_manager',
+				'x_g_nci_app_tracke.committee_member',
+			];
+			const tenants = [{ value: 'tenant-1', roles }];
+
+			expect(isVacancyManager('tenant-1', tenants)).toEqual(roles);
+		});
+
+		it('returns false when role exists but not at index 0', () => {
+			const tenants = [
+				{
+					value: 'tenant-1',
+					roles: [
+						'x_g_nci_app_tracke.committee_member',
+						'x_g_nci_app_tracke.vacancy_manager',
+					],
+				},
+			];
+
+			expect(isVacancyManager('tenant-1', tenants)).toBe(false);
+		});
+
+		it('returns false when tenant does not match', () => {
+			const tenants = [
+				{
+					value: 'tenant-2',
+					roles: ['x_g_nci_app_tracke.vacancy_manager'],
+				},
+			];
+
+			expect(isVacancyManager('tenant-1', tenants)).toBe(false);
+		});
+	});
+
+	describe('isExecSec', () => {
+		it('returns false when tenants is undefined', () => {
+			expect(isExecSec('tenant-1', undefined)).toBe(false);
+		});
+
+		it('returns true when matching tenant is exec sec', () => {
+			const tenants = [{ value: 'tenant-1', is_exec_sec: true }];
+			expect(isExecSec('tenant-1', tenants)).toBe(true);
+		});
+
+		it('returns false when matching tenant is not exec sec', () => {
+			const tenants = [{ value: 'tenant-1', is_exec_sec: false }];
+			expect(isExecSec('tenant-1', tenants)).toBe(false);
+		});
+	});
+
+	describe('isChair', () => {
+		it('returns false when tenants is undefined', () => {
+			expect(isChair('tenant-1', undefined)).toBe(false);
+		});
+
+		it('returns true when matching tenant is chair', () => {
+			const tenants = [{ value: 'tenant-1', is_chair: true }];
+			expect(isChair('tenant-1', tenants)).toBe(true);
+		});
+
+		it('returns false when matching tenant is not chair', () => {
+			const tenants = [{ value: 'tenant-1', is_chair: false }];
+			expect(isChair('tenant-1', tenants)).toBe(false);
+		});
+	});
+
+	describe('isCommitteMember', () => {
+		it('returns false when tenants is undefined', () => {
+			expect(isCommitteMember('tenant-1', undefined)).toBe(false);
+		});
+
+		it('returns true when matching tenant has is_member true', () => {
+			const tenants = [
+				{ value: 'tenant-1', is_member: true, is_read_only_user: false },
+			];
+			expect(isCommitteMember('tenant-1', tenants)).toBe(true);
+		});
+
+		it('returns true when matching tenant has read-only user true', () => {
+			const tenants = [
+				{ value: 'tenant-1', is_member: false, is_read_only_user: true },
+			];
+			expect(isCommitteMember('tenant-1', tenants)).toBe(true);
+		});
+
+		it('returns false when matching tenant is neither member nor read-only user', () => {
+			const tenants = [
+				{ value: 'tenant-1', is_member: false, is_read_only_user: false },
+			];
+			expect(isCommitteMember('tenant-1', tenants)).toBe(false);
+		});
+	});
+
+	describe('isHrSpecialist', () => {
+		it('returns false when tenants is undefined', () => {
+			expect(isHrSpecialist('tenant-1', undefined)).toBe(false);
+		});
+
+		it('returns true when matching tenant has hr flag', () => {
+			const tenants = [{ value: 'tenant-1', is_hr: true }];
+			expect(isHrSpecialist('tenant-1', tenants)).toBe(true);
+		});
+
+		it('returns false when matching tenant does not have hr flag', () => {
+			const tenants = [{ value: 'tenant-1', is_hr: false }];
+			expect(isHrSpecialist('tenant-1', tenants)).toBe(false);
+		});
+	});
+
+	describe('atleastOneChair', () => {
+		it('returns false when tenants is undefined', () => {
+			expect(atleastOneChair(undefined)).toBe(false);
+		});
+
+		it('returns true when at least one tenant is chair', () => {
+			const tenants = [
+				{ value: 'tenant-1', is_chair: false },
+				{ value: 'tenant-2', is_chair: true },
+			];
+			expect(atleastOneChair(tenants)).toBe(true);
+		});
+
+		it('returns false when no tenant is chair', () => {
+			const tenants = [
+				{ value: 'tenant-1', is_chair: false },
+				{ value: 'tenant-2', is_chair: false },
+			];
+			expect(atleastOneChair(tenants)).toBe(false);
+		});
+	});
+});

--- a/src/components/Util/RoleValidator/RoleValidator.test.js
+++ b/src/components/Util/RoleValidator/RoleValidator.test.js
@@ -97,17 +97,17 @@ describe('RoleValidator utilities', () => {
 			expect(isVacancyManager('tenant-1', undefined)).toBe(false);
 		});
 
-		it('returns roles array when matching tenant has vacancy manager role at index 0', () => {
+		it('returns true when matching tenant has vacancy manager role', () => {
 			const roles = [
 				'x_g_nci_app_tracke.vacancy_manager',
 				'x_g_nci_app_tracke.committee_member',
 			];
 			const tenants = [{ value: 'tenant-1', roles }];
 
-			expect(isVacancyManager('tenant-1', tenants)).toEqual(roles);
+			expect(isVacancyManager('tenant-1', tenants)).toBe(true);
 		});
 
-		it('returns false when role exists but not at index 0', () => {
+		it('returns true when role exists outside index 0', () => {
 			const tenants = [
 				{
 					value: 'tenant-1',
@@ -117,6 +117,12 @@ describe('RoleValidator utilities', () => {
 					],
 				},
 			];
+
+			expect(isVacancyManager('tenant-1', tenants)).toBe(true);
+		});
+
+		it('returns false when matching tenant roles is not an array', () => {
+			const tenants = [{ value: 'tenant-1', roles: null }];
 
 			expect(isVacancyManager('tenant-1', tenants)).toBe(false);
 		});

--- a/src/containers/ChairDashboard/ChairDashboard.js
+++ b/src/containers/ChairDashboard/ChairDashboard.js
@@ -31,62 +31,73 @@ const chairDashboard = () => {
 	const history = useHistory();
 
 	useEffect(() => {
-		if (
-			validateRoleForCurrentTenant(
-				COMMITTEE_MEMBER_ROLE,
-				currentTenant,
-				tenants
-			)
-		) {
-			(async () => {
-				setHasError(false);
-				setIsLoading(true);
-				try {
-					const currentData = await axios.get(
-						GET_COMMITTEE_CHAIR_VACANCIES + currentTenant
-					);
-					const jsonData = currentData.data.result;
+		if (currentTenant) {
+			if (
+				validateRoleForCurrentTenant(
+					COMMITTEE_MEMBER_ROLE,
+					currentTenant,
+					tenants
+				)
+			) {
+				(async () => {
+					setHasError(false);
+					setIsLoading(true);
+					try {
+						const currentData = await axios.get(
+							GET_COMMITTEE_CHAIR_VACANCIES + currentTenant
+						);
+						const jsonData = currentData.data.result;
 
-					const validateData = validateVacancyData(jsonData);
+						const validateData = validateVacancyData(jsonData);
 
-					setData(
-						validateData?.list.filter(
-							(vacancy) => vacancy.status != 'live' && vacancy.status != 'final'
-						)
-					);
-				} catch (err) {
-					setHasError(true);
-					notification.error({
-						message: 'Sorry! There was an error retrieving vacancies.',
-						description: (
-							<>
-								<p>
-									Please refresh the page and try again or try logging out and
-									logging back in. If the issue persists, contact the Help Desk
-									by emailing{' '}
-									<a href='mailto:NCIAppSupport@mail.nih.gov'>
-										NCIAppSupport@mail.nih.gov
-									</a>
-								</p>
-							</>
-						),
-						duration: 30,
-						style: {
-							height: '225px',
-							display: 'flex',
-							alignItems: 'center',
-						},
-					});
-				} finally {
-					setIsLoading(false);
-				}
-			})();
+						setData(
+							validateData?.list.filter(
+								(vacancy) =>
+									vacancy.status != 'live' && vacancy.status != 'final'
+							)
+						);
+					} catch (err) {
+						setHasError(true);
+						notification.error({
+							message: 'Sorry! There was an error retrieving vacancies.',
+							description: (
+								<>
+									<p>
+										Please refresh the page and try again or try logging out and
+										logging back in. If the issue persists, contact the Help
+										Desk by emailing{' '}
+										<a href='mailto:NCIAppSupport@mail.nih.gov'>
+											NCIAppSupport@mail.nih.gov
+										</a>
+									</p>
+								</>
+							),
+							duration: 30,
+							style: {
+								height: '225px',
+								display: 'flex',
+								alignItems: 'center',
+							},
+						});
+					} finally {
+						setIsLoading(false);
+					}
+				})();
+			} else {
+				message.destroy();
+				message.error({
+					duration: 3,
+					content:
+						'Sorry! You do not have committee member access in the selected tenant.',
+				});
+				setIsLoading(false);
+				history.push('/');
+			}
 		} else {
 			message.destroy();
 			message.error({
 				duration: 3,
-				content:
-					'Sorry! You do not have committee member access in the selected tenant.',
+				content: 'Sorry! Please reselect your tenant and try again.',
 			});
 			setIsLoading(false);
 			history.push('/');

--- a/src/containers/ChairDashboard/ChairDashboard.js
+++ b/src/containers/ChairDashboard/ChairDashboard.js
@@ -8,6 +8,7 @@ import { GET_COMMITTEE_CHAIR_VACANCIES } from '../../constants/ApiEndpoints';
 import './ChairDashboard.css';
 import axios from 'axios';
 import { LoadingOutlined } from '@ant-design/icons';
+import { isChair } from '../../components/Util/RoleValidator/RoleValidator';
 import { validateRoleForCurrentTenant } from '../../components/Util/RoleValidator/RoleValidator';
 import { COMMITTEE_MEMBER_ROLE } from '../../constants/Roles.js';
 import useAuth from '../../hooks/useAuth';
@@ -21,6 +22,10 @@ import {
 } from './Utils/statusHelper.js';
 
 const chairDashboard = () => {
+	const noAssignedVacanciesMessage =
+		'Sorry! You do not have any vacancies assigned to you in the selected tenant.';
+	const liveOrFinalVacanciesMessage =
+		"Sorry! Your assigned vacancy is still in 'Live' or 'Final' status and cannot be accessed from this dashboard yet.";
 	const {
 		auth: { tenants },
 		currentTenant,
@@ -32,13 +37,15 @@ const chairDashboard = () => {
 
 	useEffect(() => {
 		if (currentTenant) {
-			if (
+			const hasChairAccess =
+				isChair(currentTenant, tenants) ||
 				validateRoleForCurrentTenant(
 					COMMITTEE_MEMBER_ROLE,
 					currentTenant,
 					tenants
-				)
-			) {
+				);
+
+			if (hasChairAccess) {
 				(async () => {
 					setHasError(false);
 					setIsLoading(true);
@@ -49,13 +56,32 @@ const chairDashboard = () => {
 						const jsonData = currentData.data.result;
 
 						const validateData = validateVacancyData(jsonData);
-
-						setData(
-							validateData?.list.filter(
-								(vacancy) =>
-									vacancy.status != 'live' && vacancy.status != 'final'
-							)
+						const vacancyList = validateData?.list || [];
+						const filteredVacancies = vacancyList.filter(
+							(vacancy) =>
+								vacancy.status != 'live' && vacancy.status != 'final'
 						);
+
+						if (filteredVacancies.length === 0) {
+							const hasOnlyLiveOrFinalVacancies =
+								vacancyList.length > 0 &&
+								vacancyList.every(
+									(vacancy) =>
+										vacancy.status == 'live' || vacancy.status == 'final'
+								);
+							message.destroy();
+							message.error({
+								duration: 3,
+								content: hasOnlyLiveOrFinalVacancies
+									? liveOrFinalVacanciesMessage
+									: noAssignedVacanciesMessage,
+							});
+							setData([]);
+							history.push('/');
+							return;
+						}
+
+						setData(filteredVacancies);
 					} catch (err) {
 						setHasError(true);
 						notification.error({
@@ -87,8 +113,7 @@ const chairDashboard = () => {
 				message.destroy();
 				message.error({
 					duration: 3,
-					content:
-						'Sorry! You do not have committee member access in the selected tenant.',
+					content: noAssignedVacanciesMessage,
 				});
 				setIsLoading(false);
 				history.push('/');

--- a/src/containers/ChairDashboard/ChairDashboard.test.js
+++ b/src/containers/ChairDashboard/ChairDashboard.test.js
@@ -4,6 +4,7 @@ import { notification } from 'antd';
 import axios from 'axios';
 import { GET_COMMITTEE_CHAIR_VACANCIES } from '../../constants/ApiEndpoints';
 import useAuth from '../../hooks/useAuth';
+import { isChair } from '../../components/Util/RoleValidator/RoleValidator';
 import { validateRoleForCurrentTenant } from '../../components/Util/RoleValidator/RoleValidator';
 import { useHistory } from 'react-router-dom';
 import { waitFor, screen, fireEvent } from '@testing-library/react';
@@ -85,6 +86,7 @@ describe('ChairDashboard component tests', () => {
 			},
 			currentTenant: 'f24965fc1b9c11106daea681f54bcb04', // Match the tenant value
 		});
+		isChair.mockReturnValue(true);
 		validateRoleForCurrentTenant.mockReturnValue(true);
 		axios.get.mockResolvedValue({ data: { result: mockVacancies } });
 	});
@@ -141,12 +143,13 @@ describe('ChairDashboard component tests', () => {
 		expect(screen.queryByText('Final Job')).not.toBeInTheDocument();
 	});
 
-	test('<ChairDashboard /> should show error when user is not a committee member', async () => {
+	test('<ChairDashboard /> should redirect when selected tenant is not a chair tenant', async () => {
 		const mockPush = jest.fn();
 		jest.requireMock('react-router-dom').useHistory.mockReturnValue({
 			push: mockPush,
 		});
 
+		isChair.mockReturnValueOnce(false);
 		validateRoleForCurrentTenant.mockReturnValueOnce(false);
 
 		rtRender(<ChairDashboard />);
@@ -155,13 +158,149 @@ describe('ChairDashboard component tests', () => {
 			() => {
 				expect(
 					screen.getByText(
-						'Sorry! You do not have committee member access in the selected tenant.'
+						'Sorry! You do not have any vacancies assigned to you in the selected tenant.'
 					)
 				).toBeInTheDocument();
 			},
 			{ timeout: 2000 }
 		);
 		expect(mockPush).toHaveBeenCalledWith('/');
+		expect(axios.get).not.toHaveBeenCalled();
+	});
+
+	test('<ChairDashboard /> should redirect when selected chair tenant has no assigned vacancies', async () => {
+		const mockPush = jest.fn();
+		jest.requireMock('react-router-dom').useHistory.mockReturnValue({
+			push: mockPush,
+		});
+
+		isChair.mockReturnValueOnce(true);
+		axios.get.mockResolvedValueOnce({ data: { result: { status: 200, list: [] } } });
+
+		rtRender(<ChairDashboard />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(
+					'Sorry! You do not have any vacancies assigned to you in the selected tenant.'
+				)
+			).toBeInTheDocument();
+		});
+		expect(mockPush).toHaveBeenCalledWith('/');
+	});
+
+	test('<ChairDashboard /> should redirect with live/final message when assigned vacancies are only live/final', async () => {
+		const mockPush = jest.fn();
+		jest.requireMock('react-router-dom').useHistory.mockReturnValue({
+			push: mockPush,
+		});
+
+		isChair.mockReturnValueOnce(true);
+		axios.get.mockResolvedValueOnce({
+			data: {
+				result: {
+					status: 200,
+					list: [
+						{ vacancy_id: 10, vacancy_title: 'Live Vacancy', status: 'live' },
+						{ vacancy_id: 11, vacancy_title: 'Final Vacancy', status: 'final' },
+					],
+				},
+			},
+		});
+
+		rtRender(<ChairDashboard />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(
+					"Sorry! Your assigned vacancy is still in 'Live' or 'Final' status and cannot be accessed from this dashboard yet."
+				)
+			).toBeInTheDocument();
+		});
+		expect(mockPush).toHaveBeenCalledWith('/');
+	});
+
+	test('<ChairDashboard /> should redirect after tenant switch to a tenant without chair access', async () => {
+		const mockPush = jest.fn();
+		jest.requireMock('react-router-dom').useHistory.mockReturnValue({
+			push: mockPush,
+		});
+
+		let mockedCurrentTenant = 'tenant-chair';
+		const mockedTenants = [
+			{
+				value: 'tenant-chair',
+				label: 'Chair Tenant',
+				roles: ['x_g_nci_app_tracke.committee_member'],
+				is_chair: true,
+			},
+			{
+				value: 'tenant-no-chair',
+				label: 'No Chair Tenant',
+				roles: ['x_g_nci_app_tracke.committee_member'],
+				is_chair: false,
+			},
+		];
+
+		useAuth.mockImplementation(() => ({
+			auth: { tenants: mockedTenants },
+			currentTenant: mockedCurrentTenant,
+		}));
+
+		isChair.mockImplementation((tenant) => tenant === 'tenant-chair');
+		validateRoleForCurrentTenant.mockImplementation(
+			(role, tenant) => tenant === 'tenant-chair'
+		);
+		axios.get.mockResolvedValueOnce({ data: { result: mockVacancies } });
+
+		const { rerender } = rtRender(<ChairDashboard />);
+		await screen.findByText('Senior Dev');
+
+		mockedCurrentTenant = 'tenant-no-chair';
+		rerender(<ChairDashboard />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(
+					'Sorry! You do not have any vacancies assigned to you in the selected tenant.'
+				)
+			).toBeInTheDocument();
+		});
+		expect(mockPush).toHaveBeenCalledWith('/');
+	});
+
+	test('<ChairDashboard /> should redirect home when current tenant is missing', async () => {
+		const mockPush = jest.fn();
+		jest.requireMock('react-router-dom').useHistory.mockReturnValue({
+			push: mockPush,
+		});
+
+		useAuth.mockReturnValue({
+			auth: {
+				tenants: [
+					{
+						value: 'f24965fc1b9c11106daea681f54bcb04',
+						label: 'tenant 1',
+						roles: [
+							'x_g_nci_app_tracke.vacancy_manager',
+							'x_g_nci_app_tracke.committee_member',
+						],
+						is_chair: true,
+					},
+				],
+			},
+			currentTenant: undefined,
+		});
+
+		rtRender(<ChairDashboard />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText('Sorry! Please reselect your tenant and try again.')
+			).toBeInTheDocument();
+		});
+		expect(mockPush).toHaveBeenCalledWith('/');
+		expect(axios.get).not.toHaveBeenCalled();
 	});
 
 	test('<ChairDashboard /> should display error message when API fails', async () => {
@@ -250,14 +389,25 @@ describe('ChairDashboard component tests', () => {
 		expect(applicantsLink).toHaveAttribute('href', '#/manage/vacancy/1/applicants');
 	});
 
-	test('<ChairDashboard /> should render empty state when no vacancies', async () => {
+	test('<ChairDashboard /> should redirect when API returns no assigned vacancies', async () => {
 		const emptyVacancies = {
 			status: 200,
 			list: [],
 		};
 		axios.get.mockResolvedValue({ data: { result: emptyVacancies } });
+		const mockPush = jest.fn();
+		jest.requireMock('react-router-dom').useHistory.mockReturnValue({
+			push: mockPush,
+		});
 		rtRender(<ChairDashboard />);
-		expect(await screen.findByText('Vacancies Assigned To You')).toBeInTheDocument();
+		await waitFor(() => {
+			expect(
+				screen.getByText(
+					'Sorry! You do not have any vacancies assigned to you in the selected tenant.'
+				)
+			).toBeInTheDocument();
+		});
+		expect(mockPush).toHaveBeenCalledWith('/');
 	});
 
 	test('<ChairDashboard /> should display all vacancies when no filter matches', async () => {
@@ -383,5 +533,38 @@ describe('ChairDashboard component tests', () => {
 
 		expect(await screen.findByText('No Applicant Count Job')).toBeInTheDocument();
 		expect(await screen.findByText('0 applicants')).toBeInTheDocument();
+	});
+
+	test('<ChairDashboard /> should handle validateVacancyData returning object without list', async () => {
+		const mockPush = jest.fn();
+		jest.requireMock('react-router-dom').useHistory.mockReturnValue({
+			push: mockPush,
+		});
+
+		isChair.mockReturnValueOnce(true);
+		
+		// Mock validateVacancyData to return object without list property
+		const validateVacancyDataModule = require('./Utils/validateVacancyData');
+		jest.spyOn(validateVacancyDataModule, 'validateVacancyData').mockReturnValueOnce({});
+		
+		axios.get.mockResolvedValueOnce({
+			data: {
+				result: {
+					status: 200,
+					list: [{ vacancy_id: 1, vacancy_title: 'Test', status: 'open' }],
+				},
+			},
+		});
+
+		rtRender(<ChairDashboard />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(
+					'Sorry! You do not have any vacancies assigned to you in the selected tenant.'
+				)
+			).toBeInTheDocument();
+		});
+		expect(mockPush).toHaveBeenCalledWith('/');
 	});
 });

--- a/src/containers/CommitteeDashboard/CommitteeDashboard.js
+++ b/src/containers/CommitteeDashboard/CommitteeDashboard.js
@@ -62,66 +62,77 @@ const committeeDashboard = () => {
 	);
 
 	useEffect(() => {
-		if (
-			validateRoleForCurrentTenant(
-				COMMITTEE_MEMBER_ROLE,
-				currentTenant,
-				tenants
-			) ||
-			isExecSec(currentTenant, tenants)
-		) {
-			(async () => {
-				setHasError(false);
-				setIsLoading(true);
-				try {
-					setreadOnly(user.isReadOnlyUser);
-					const url = GET_COMMITTEE_MEMBER_VIEW + currentTenant;
-					const currentData = await axios.get(url);
+		if (currentTenant) {
+			if (
+				validateRoleForCurrentTenant(
+					COMMITTEE_MEMBER_ROLE,
+					currentTenant,
+					tenants
+				) ||
+				isExecSec(currentTenant, tenants)
+			) {
+				(async () => {
+					setHasError(false);
+					setIsLoading(true);
+					try {
+						setreadOnly(user.isReadOnlyUser);
+						const url = GET_COMMITTEE_MEMBER_VIEW + currentTenant;
+						const currentData = await axios.get(url);
 
-					const jsonData = currentData.data.result;
+						const jsonData = currentData.data.result;
 
-				const validatedData = validateVacancyData(jsonData);
+						const validatedData = validateVacancyData(jsonData);
 
-					const committeeMemberData =
-						location.pathname === EXE_SEC_DASHBOARD
-							? validatedData?.list.filter(
-									(vacancy) => vacancy.user_role === COMMITTEE_EXEC_SEC
-								)
-							: validatedData?.list;
-					setData(committeeMemberData);
-				} catch (err) {
-					setHasError(true);
-					notification.error({
-						message: 'Sorry! There was an error retrieving vacancies.',
-						description: (
-							<>
-								<p>
-									Please refresh the page and try again or try logging out and
-									logging back in. If the issue persists, contact the Help Desk
-									by emailing{' '}
-									<a href='mailto:NCIAppSupport@mail.nih.gov'>
-										NCIAppSupport@mail.nih.gov
-									</a>
-								</p>
-							</>
-						),
-						duration: 30,
-						style: {
-							height: '225px',
-							display: 'flex',
-							alignItems: 'center',
-						},
-					});
-				} finally {
-					setIsLoading(false);
-				}
-			})();
+						const committeeMemberData =
+							location.pathname === EXE_SEC_DASHBOARD
+								? validatedData?.list.filter(
+										(vacancy) => vacancy.user_role === COMMITTEE_EXEC_SEC
+									)
+								: validatedData?.list;
+						setData(committeeMemberData);
+					} catch (err) {
+						setHasError(true);
+						notification.error({
+							message: 'Sorry! There was an error retrieving vacancies.',
+							description: (
+								<>
+									<p>
+										Please refresh the page and try again or try logging out and
+										logging back in. If the issue persists, contact the Help
+										Desk by emailing{' '}
+										<a href='mailto:NCIAppSupport@mail.nih.gov'>
+											NCIAppSupport@mail.nih.gov
+										</a>
+									</p>
+								</>
+							),
+							duration: 30,
+							style: {
+								height: '225px',
+								display: 'flex',
+								alignItems: 'center',
+							},
+						});
+					} finally {
+						setIsLoading(false);
+					}
+				})();
+			} else {
+				message.destroy();
+				message.error({
+					duration: 3,
+					content:
+						'Sorry! You do not have committee member access in the selected tenant.',
+				});
+				setIsLoading(false);
+				history.push('/');
+			}
 		} else {
 			message.destroy();
 			message.error({
 				duration: 3,
 				content:
-					'Sorry! You do not have committee member access in the selected tenant.',
+					'Sorry! Please reselect your tenant and try again.'
 			});
 			setIsLoading(false);
 			history.push('/');

--- a/src/containers/CommitteeDashboard/CommitteeDashboard.test.js
+++ b/src/containers/CommitteeDashboard/CommitteeDashboard.test.js
@@ -148,6 +148,33 @@ describe('CommitteeDashboard component tests', () => {
 		});
 	});
 
+	test('<CommitteeDashboard /> should redirect when current tenant is missing', async () => {
+		const mockPush = jest.fn();
+		jest.requireMock('react-router-dom').useHistory.mockReturnValue({
+			push: mockPush,
+		});
+
+		const antd = jest.requireMock('antd');
+		useAuth.mockReturnValue({
+			auth: {
+				tenants: mockTenants,
+				user: { isReadOnlyUser: false },
+			},
+			currentTenant: null,
+		});
+
+		rtRender(<CommitteeDashboard />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText('Sorry! Please reselect your tenant and try again.')
+			).toBeInTheDocument();
+			expect(mockPush).toHaveBeenCalledWith('/');
+		});
+
+		expect(axios.get).not.toHaveBeenCalled();
+	});
+
 	test('<CommitteeDashboard /> should display error when invalid list shape is provided', async () => {
 		// Test that invalid list shape throws and triggers error UI
 		const invalidData = {
@@ -167,6 +194,19 @@ describe('CommitteeDashboard component tests', () => {
 			},
 			{ timeout: 3000 }
 		);
+
+		expect(
+			screen.getByText(/Please refresh the page and try again\./i)
+		).toBeInTheDocument();
+		const helpDeskLinks = screen.getAllByRole('link', {
+			name: 'NCIAppSupport@mail.nih.gov',
+		});
+		expect(
+			helpDeskLinks.some(
+				(link) =>
+					link.getAttribute('href') === 'mailto:NCIAppSupport@mail.nih.gov'
+			)
+		).toBe(true);
 	});
 
 	test('<CommitteeDashboard /> should call validateRoleForCurrentTenant on load', async () => {

--- a/src/containers/CommitteeDashboard/CommitteeDashboard.test.js
+++ b/src/containers/CommitteeDashboard/CommitteeDashboard.test.js
@@ -154,7 +154,6 @@ describe('CommitteeDashboard component tests', () => {
 			push: mockPush,
 		});
 
-		const antd = jest.requireMock('antd');
 		useAuth.mockReturnValue({
 			auth: {
 				tenants: mockTenants,

--- a/src/hoc/Layout/Layout.test.js
+++ b/src/hoc/Layout/Layout.test.js
@@ -21,8 +21,12 @@ describe('Layout', () => {
                     isChair: false,
                     roles: [],
                     hasApplications: true
-                }
-            }
+                },
+                tenants: [],
+            },
+            currentTenant: undefined,
+            setCurrentTenant: jest.fn(),
+            previousTenant: undefined,
         });
 
         const { getAllByText } = render(
@@ -45,6 +49,8 @@ describe('Layout', () => {
     it('renders Header, NavBar, ContentTitle, Footer and children correctly when a manager is logged in', () => {
         useAuth.mockReturnValue({
             currentTenant: 'tenant 1',
+            setCurrentTenant: jest.fn(),
+            previousTenant: undefined,
             auth: {
                 isUserLoggedIn: true,
                 user: {
@@ -122,6 +128,8 @@ describe('Layout', () => {
 
             },
             currentTenant: 'tenant 1',
+            setCurrentTenant: jest.fn(),
+            previousTenant: undefined,
         });
 
         const { getAllByText } = render(
@@ -168,6 +176,8 @@ describe('Layout', () => {
                 ],
             },
             currentTenant: 'f24965fc1b9c11106daea681f54bcb04',
+            setCurrentTenant: jest.fn(),
+            previousTenant: undefined,
         });
 
         const { getAllByText } = render(
@@ -191,8 +201,12 @@ describe('Layout', () => {
         useAuth.mockReturnValue({
             auth: {
                 isUserLoggedIn: false,
-                user: {}
-            }
+                user: {},
+                tenants: [],
+            },
+            currentTenant: undefined,
+            setCurrentTenant: jest.fn(),
+            previousTenant: undefined,
         });
 
         const { getAllByText, getByText } = render(
@@ -215,7 +229,11 @@ describe('Layout', () => {
             auth: {
                 bannerMessage: 'System maintenance planned',
                 bannerDescription: 'The site will be down <strong>tonight</strong> from 11pm-1am.',
+                tenants: [],
             },
+            currentTenant: undefined,
+            setCurrentTenant: jest.fn(),
+            previousTenant: undefined,
         });
 
         render(
@@ -233,7 +251,11 @@ describe('Layout', () => {
         useAuth.mockReturnValue({
             auth: {
                 // no bannerMessage or bannerDescription provided
-            }
+                tenants: [],
+            },
+            currentTenant: undefined,
+            setCurrentTenant: jest.fn(),
+            previousTenant: undefined,
         });
 
         render(

--- a/src/hoc/Layout/Layout.test.js
+++ b/src/hoc/Layout/Layout.test.js
@@ -2,10 +2,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Layout from './Layout';
-import Header from '../../components/Header/Header';
-import NavBar from '../../components/NavBar/NavBar';
-import ContentTitle from './ContentTitle/ContentTitle';
-import Footer from '../../components/Footer/Footer';
 import useAuth from '../../hooks/useAuth';
 
 jest.mock('../../hooks/useAuth');
@@ -48,7 +44,7 @@ describe('Layout', () => {
 
     it('renders Header, NavBar, ContentTitle, Footer and children correctly when a manager is logged in', () => {
         useAuth.mockReturnValue({
-            currentTenant: 'tenant 1',
+            currentTenant: 'f24965fc1b9c11106daea681f54bcb04',
             setCurrentTenant: jest.fn(),
             previousTenant: undefined,
             auth: {
@@ -90,7 +86,6 @@ describe('Layout', () => {
 
         const vacancyDashboardLinks = getAllByText('Vacancy Dashboard');
         expect(vacancyDashboardLinks.length).toBeGreaterThan(0);
-        console.log(vacancyDashboardLinks);
         const vacancyDashboardLink = vacancyDashboardLinks.find(link => link.getAttribute('href') === '/vacancy-dashboard');
         expect(vacancyDashboardLink).toBeInTheDocument();
 
@@ -227,6 +222,8 @@ describe('Layout', () => {
     test('renders banner Alert when auth contains bannerMessage and description', () => {
         useAuth.mockReturnValue({
             auth: {
+                isUserLoggedIn: false,
+                user: {},
                 bannerMessage: 'System maintenance planned',
                 bannerDescription: 'The site will be down <strong>tonight</strong> from 11pm-1am.',
                 tenants: [],
@@ -250,6 +247,8 @@ describe('Layout', () => {
     test('does not render banner Alert when auth has no bannerMessage', () => {
         useAuth.mockReturnValue({
             auth: {
+                isUserLoggedIn: false,
+                user: {},
                 // no bannerMessage or bannerDescription provided
                 tenants: [],
             },

--- a/webpack/servicenow.config.js
+++ b/webpack/servicenow.config.js
@@ -15,12 +15,12 @@ const servicenowConfig = {
 	 * it is being used for sending REST calls in DEVELOPMENT mode only
 	 * no need to provide credentials for PRODUCTION
 	 */
-	REACT_APP_USER: 'john.lechuga.test.user@gmail.com',
+	REACT_APP_USER: '',
 	/**
 	 *
 	 * User password, for DEVELOPMENT mode only
 	 */
-	REACT_APP_PASSWORD: '*o89On[v',
+	REACT_APP_PASSWORD: '',
 	/**
 	 *
 	 * ServiceNow path to GET resource which serves javascript files

--- a/webpack/servicenow.config.js
+++ b/webpack/servicenow.config.js
@@ -15,12 +15,12 @@ const servicenowConfig = {
 	 * it is being used for sending REST calls in DEVELOPMENT mode only
 	 * no need to provide credentials for PRODUCTION
 	 */
-	REACT_APP_USER: '',
+	REACT_APP_USER: 'john.lechuga.test.user@gmail.com',
 	/**
 	 *
 	 * User password, for DEVELOPMENT mode only
 	 */
-	REACT_APP_PASSWORD: '',
+	REACT_APP_PASSWORD: '*o89On[v',
 	/**
 	 *
 	 * ServiceNow path to GET resource which serves javascript files


### PR DESCRIPTION
This PR enables auto tenant selection for users that only have 1 tenant. The original multi-tenant selection workflow remains untouched.