### PR TITLE
SSJ-757 - DCEG - Committee Members Unable to Access Your Vacancies

### DIFF
--- a/src/containers/ChairDashboard/ChairDashboard.js
+++ b/src/containers/ChairDashboard/ChairDashboard.js
@@ -35,99 +35,145 @@ const chairDashboard = () => {
 	const [hasError, setHasError] = useState(false);
 	const history = useHistory();
 
-	useEffect(() => {
-		if (currentTenant) {
-			const hasChairAccess =
-				isChair(currentTenant, tenants) ||
-				validateRoleForCurrentTenant(
-					COMMITTEE_MEMBER_ROLE,
-					currentTenant,
-					tenants
-				);
+	    useEffect(() => {
+        // Stop immediately if no tenant is selected, notify the user, and go home.
+        if (!currentTenant) {
+            message.destroy();
+            message.error({
+                duration: 3,
+                content: 'Sorry! Please reselect your tenant and try again.',
+            });
+            setIsLoading(false);
+            history.push('/');
+            return;
+        }
 
-			if (hasChairAccess) {
-				(async () => {
-					setHasError(false);
-					setIsLoading(true);
-					try {
-						const currentData = await axios.get(
-							GET_COMMITTEE_CHAIR_VACANCIES + currentTenant
-						);
-						const jsonData = currentData.data.result;
+        // Wait until tenant data has finished loading before checking access.
+        if (!Array.isArray(tenants)) {
+            return;
+        }
 
-						const validateData = validateVacancyData(jsonData);
-						const vacancyList = validateData?.list || [];
-						const filteredVacancies = vacancyList.filter(
-							(vacancy) =>
-								vacancy.status != 'live' && vacancy.status != 'final'
-						);
+        // Allow this dashboard only for users who are chair in this tenant
+        // or who satisfy the fallback role check for this tenant.
+        const hasChairAccess =
+            isChair(currentTenant, tenants) ||
+            validateRoleForCurrentTenant(
+                COMMITTEE_MEMBER_ROLE,
+                currentTenant,
+                tenants
+            );
 
-						if (filteredVacancies.length === 0) {
-							const hasOnlyLiveOrFinalVacancies =
-								vacancyList.length > 0 &&
-								vacancyList.every(
-									(vacancy) =>
-										vacancy.status == 'live' || vacancy.status == 'final'
-								);
-							message.destroy();
-							message.error({
-								duration: 3,
-								content: hasOnlyLiveOrFinalVacancies
-									? liveOrFinalVacanciesMessage
-									: noAssignedVacanciesMessage,
-							});
-							setData([]);
-							history.push('/');
-							return;
-						}
+        // If the user does not have access in the selected tenant, notify and redirect.
+        if (!hasChairAccess) {
+            message.destroy();
+            message.error({
+                duration: 3,
+                content: noAssignedVacanciesMessage,
+            });
+            setIsLoading(false);
+            history.push('/');
+            return;
+        }
 
-						setData(filteredVacancies);
-					} catch (err) {
-						setHasError(true);
-						notification.error({
-							message: 'Sorry! There was an error retrieving vacancies.',
-							description: (
-								<>
-									<p>
-										Please refresh the page and try again or try logging out and
-										logging back in. If the issue persists, contact the Help
-										Desk by emailing{' '}
-										<a href='mailto:NCIAppSupport@mail.nih.gov'>
-											NCIAppSupport@mail.nih.gov
-										</a>
-									</p>
-								</>
-							),
-							duration: 30,
-							style: {
-								height: '225px',
-								display: 'flex',
-								alignItems: 'center',
-							},
-						});
-					} finally {
-						setIsLoading(false);
-					}
-				})();
-			} else {
-				message.destroy();
-				message.error({
-					duration: 3,
-					content: noAssignedVacanciesMessage,
-				});
-				setIsLoading(false);
-				history.push('/');
-			}
-		} else {
-			message.destroy();
-			message.error({
-				duration: 3,
-				content: 'Sorry! Please reselect your tenant and try again.',
-			});
-			setIsLoading(false);
-			history.push('/');
-		}
-	}, [currentTenant]);
+        // Track whether this effect is still current so async work does not update stale state.
+        let isMounted = true;
+
+        (async () => {
+            // Reset error state and show the loading spinner before fetching data.
+            setHasError(false);
+            setIsLoading(true);
+
+            try {
+                // Fetch the chair vacancies for the currently selected tenant.
+                const currentData = await axios.get(
+                    GET_COMMITTEE_CHAIR_VACANCIES + currentTenant
+                );
+                const jsonData = currentData.data.result;
+
+                // Validate the API payload and normalize access to the vacancy list.
+                const validateData = validateVacancyData(jsonData);
+                const vacancyList = validateData?.list || [];
+
+                // Remove vacancies that are still in live/final states because this dashboard
+                // only shows vacancies that can be acted on here.
+                const filteredVacancies = vacancyList.filter(
+                    (vacancy) =>
+                        vacancy.status != 'live' && vacancy.status != 'final'
+                );
+
+                // Stop if the component unmounted or the effect was replaced while waiting.
+                if (!isMounted) {
+                    return;
+                }
+
+                // If nothing remains after filtering, decide which user message to show,
+                // clear data, and redirect away from the dashboard.
+                if (filteredVacancies.length === 0) {
+                    const hasOnlyLiveOrFinalVacancies =
+                        vacancyList.length > 0 &&
+                        vacancyList.every(
+                            (vacancy) =>
+                                vacancy.status == 'live' || vacancy.status == 'final'
+                        );
+
+                    message.destroy();
+                    message.error({
+                        duration: 3,
+                        content: hasOnlyLiveOrFinalVacancies
+                            ? liveOrFinalVacanciesMessage
+                            : noAssignedVacanciesMessage,
+                    });
+                    setData([]);
+                    history.push('/');
+                    return;
+                }
+
+                // Save the filtered vacancies so the table can render them.
+                setData(filteredVacancies);
+            } catch (err) {
+                // Stop if the effect is no longer current before updating UI state.
+                if (!isMounted) {
+                    return;
+                }
+
+                // Show the fallback error UI and a notification if the request fails
+                // or the response cannot be processed.
+                setHasError(true);
+                notification.error({
+                    message: 'Sorry! There was an error retrieving vacancies.',
+                    description: (
+                        <>
+                            <p>
+                                Please refresh the page and try again or try logging out and
+                                logging back in. If the issue persists, contact the Help Desk by
+                                emailing{' '}
+                                <a href='mailto:NCIAppSupport@mail.nih.gov'>
+                                    NCIAppSupport@mail.nih.gov
+                                </a>
+                            </p>
+                        </>
+                    ),
+                    duration: 30,
+                    style: {
+                        height: '225px',
+                        display: 'flex',
+                        alignItems: 'center',
+                    },
+                });
+            } finally {
+                // Turn off loading only if this effect instance is still active.
+                if (isMounted) {
+                    setIsLoading(false);
+                }
+            }
+        })();
+
+        // Cleanup marks this effect instance as stale so late async completions
+        // do not update state after unmount or dependency changes.
+        return () => {
+            isMounted = false;
+        };
+    }, [currentTenant, tenants, history]);
 
 	return hasError ? (
 		<div className='Content'>

--- a/src/containers/ChairDashboard/ChairDashboard.js
+++ b/src/containers/ChairDashboard/ChairDashboard.js
@@ -3,7 +3,6 @@ import { Link, useHistory } from 'react-router-dom';
 import { MANAGE_VACANCY } from '../../constants/Routes.js';
 import { Table, message, notification, Tooltip } from 'antd';
 import { ExclamationCircleOutlined } from '@ant-design/icons';
-// import { validateVacancyData } from './Utils/validateVacancyData.js';
 import { GET_COMMITTEE_CHAIR_VACANCIES } from '../../constants/ApiEndpoints';
 import './ChairDashboard.css';
 import axios from 'axios';

--- a/src/containers/ChairDashboard/ChairDashboard.js
+++ b/src/containers/ChairDashboard/ChairDashboard.js
@@ -3,7 +3,7 @@ import { Link, useHistory } from 'react-router-dom';
 import { MANAGE_VACANCY } from '../../constants/Routes.js';
 import { Table, message, notification, Tooltip } from 'antd';
 import { ExclamationCircleOutlined } from '@ant-design/icons';
-import { validateVacancyData } from './Utils/validateVacancyData.js';
+// import { validateVacancyData } from './Utils/validateVacancyData.js';
 import { GET_COMMITTEE_CHAIR_VACANCIES } from '../../constants/ApiEndpoints';
 import './ChairDashboard.css';
 import axios from 'axios';
@@ -35,145 +35,126 @@ const chairDashboard = () => {
 	const [hasError, setHasError] = useState(false);
 	const history = useHistory();
 
-	    useEffect(() => {
-        // Stop immediately if no tenant is selected, notify the user, and go home.
-        if (!currentTenant) {
-            message.destroy();
-            message.error({
-                duration: 3,
-                content: 'Sorry! Please reselect your tenant and try again.',
-            });
-            setIsLoading(false);
-            history.push('/');
-            return;
-        }
+	useEffect(() => {
+		console.log('ChairDashboard mount/update', {
+			currentTenant,
+			tenantsLoaded: !!tenants,
+		});
 
-        // Wait until tenant data has finished loading before checking access.
-        if (!Array.isArray(tenants)) {
-            return;
-        }
+		if (currentTenant) {
+			if (!tenants) {
+				// Wait for tenants to load
+				console.log('ChairDashboard waiting for tenants to load');
+				return;
+			}
 
-        // Allow this dashboard only for users who are chair in this tenant
-        // or who satisfy the fallback role check for this tenant.
-        const hasChairAccess =
-            isChair(currentTenant, tenants) ||
-            validateRoleForCurrentTenant(
-                COMMITTEE_MEMBER_ROLE,
-                currentTenant,
-                tenants
-            );
+			const hasChairAccess =
+				isChair(currentTenant, tenants) ||
+				validateRoleForCurrentTenant(
+					COMMITTEE_MEMBER_ROLE,
+					currentTenant,
+					tenants
+				);
 
-        // If the user does not have access in the selected tenant, notify and redirect.
-        if (!hasChairAccess) {
-            message.destroy();
-            message.error({
-                duration: 3,
-                content: noAssignedVacanciesMessage,
-            });
-            setIsLoading(false);
-            history.push('/');
-            return;
-        }
+			if (hasChairAccess) {
+				(async () => {
+					setHasError(false);
+					setIsLoading(true);
+					try {
+						console.log('ChairDashboard fetching vacancies', {
+							currentTenant,
+						});
+						const currentData = await axios.get(
+							GET_COMMITTEE_CHAIR_VACANCIES + currentTenant
+						);
+						console.log('ChairDashboard API response', currentData?.data);
 
-        // Track whether this effect is still current so async work does not update stale state.
-        let isMounted = true;
+						const jsonData = currentData?.data?.result || {};
+						console.log('ChairDashboard result payload', jsonData);
 
-        (async () => {
-            // Reset error state and show the loading spinner before fetching data.
-            setHasError(false);
-            setIsLoading(true);
+						// Validate that result has required list field
+						if (!Array.isArray(jsonData?.list)) {
+							throw new Error('API response missing required list field');
+						}
 
-            try {
-                // Fetch the chair vacancies for the currently selected tenant.
-                const currentData = await axios.get(
-                    GET_COMMITTEE_CHAIR_VACANCIES + currentTenant
-                );
-                const jsonData = currentData.data.result;
+						const vacancyList = jsonData.list;
+						const filteredVacancies = vacancyList.filter(
+							(vacancy) =>
+								vacancy.status != 'live' && vacancy.status != 'final'
+						);
 
-                // Validate the API payload and normalize access to the vacancy list.
-                const validateData = validateVacancyData(jsonData);
-                const vacancyList = validateData?.list || [];
+						if (filteredVacancies.length === 0) {
+							const hasOnlyLiveOrFinalVacancies =
+								vacancyList.length > 0 &&
+								vacancyList.every(
+									(vacancy) =>
+										vacancy.status == 'live' || vacancy.status == 'final'
+								);
+							message.destroy();
+							message.error({
+								duration: 3,
+								content: hasOnlyLiveOrFinalVacancies
+									? liveOrFinalVacanciesMessage
+									: noAssignedVacanciesMessage,
+							});
+							setData([]);
+							history.push('/');
+							return;
+						}
 
-                // Remove vacancies that are still in live/final states because this dashboard
-                // only shows vacancies that can be acted on here.
-                const filteredVacancies = vacancyList.filter(
-                    (vacancy) =>
-                        vacancy.status != 'live' && vacancy.status != 'final'
-                );
-
-                // Stop if the component unmounted or the effect was replaced while waiting.
-                if (!isMounted) {
-                    return;
-                }
-
-                // If nothing remains after filtering, decide which user message to show,
-                // clear data, and redirect away from the dashboard.
-                if (filteredVacancies.length === 0) {
-                    const hasOnlyLiveOrFinalVacancies =
-                        vacancyList.length > 0 &&
-                        vacancyList.every(
-                            (vacancy) =>
-                                vacancy.status == 'live' || vacancy.status == 'final'
-                        );
-
-                    message.destroy();
-                    message.error({
-                        duration: 3,
-                        content: hasOnlyLiveOrFinalVacancies
-                            ? liveOrFinalVacanciesMessage
-                            : noAssignedVacanciesMessage,
-                    });
-                    setData([]);
-                    history.push('/');
-                    return;
-                }
-
-                // Save the filtered vacancies so the table can render them.
-                setData(filteredVacancies);
-            } catch (err) {
-                // Stop if the effect is no longer current before updating UI state.
-                if (!isMounted) {
-                    return;
-                }
-
-                // Show the fallback error UI and a notification if the request fails
-                // or the response cannot be processed.
-                setHasError(true);
-                notification.error({
-                    message: 'Sorry! There was an error retrieving vacancies.',
-                    description: (
-                        <>
-                            <p>
-                                Please refresh the page and try again or try logging out and
-                                logging back in. If the issue persists, contact the Help Desk by
-                                emailing{' '}
-                                <a href='mailto:NCIAppSupport@mail.nih.gov'>
-                                    NCIAppSupport@mail.nih.gov
-                                </a>
-                            </p>
-                        </>
-                    ),
-                    duration: 30,
-                    style: {
-                        height: '225px',
-                        display: 'flex',
-                        alignItems: 'center',
-                    },
-                });
-            } finally {
-                // Turn off loading only if this effect instance is still active.
-                if (isMounted) {
-                    setIsLoading(false);
-                }
-            }
-        })();
-
-        // Cleanup marks this effect instance as stale so late async completions
-        // do not update state after unmount or dependency changes.
-        return () => {
-            isMounted = false;
-        };
-    }, [currentTenant, tenants, history]);
+						setData(filteredVacancies);
+					} catch (err) {
+						console.error('ChairDashboard load failed', err);
+						console.error('ChairDashboard error details:', {
+							message: err?.message,
+							stack: err?.stack,
+							name: err?.name,
+						});
+						setHasError(true);
+						notification.error({
+							message: 'Sorry! There was an error retrieving vacancies.',
+							description: (
+								<>
+									<p>
+										Please refresh the page and try again or try logging out and
+										logging back in. If the issue persists, contact the Help
+										Desk by emailing{' '}
+										<a href='mailto:NCIAppSupport@mail.nih.gov'>
+											NCIAppSupport@mail.nih.gov
+										</a>
+									</p>
+								</>
+							),
+							duration: 30,
+							style: {
+								height: '225px',
+								display: 'flex',
+								alignItems: 'center',
+							},
+						});
+					} finally {
+						setIsLoading(false);
+					}
+				})();
+			} else {
+				message.destroy();
+				message.error({
+					duration: 3,
+					content: noAssignedVacanciesMessage,
+				});
+				setIsLoading(false);
+				history.push('/');
+			}
+		} else {
+			message.destroy();
+			message.error({
+				duration: 3,
+				content: 'Sorry! Please reselect your tenant and try again.',
+			});
+			setIsLoading(false);
+			history.push('/');
+		}
+	}, [currentTenant, tenants]);
 
 	return hasError ? (
 		<div className='Content'>

--- a/src/containers/ChairDashboard/ChairDashboard.test.js
+++ b/src/containers/ChairDashboard/ChairDashboard.test.js
@@ -303,6 +303,28 @@ describe('ChairDashboard component tests', () => {
 		expect(axios.get).not.toHaveBeenCalled();
 	});
 
+	test('<ChairDashboard /> should wait for tenants to load before checking access', async () => {
+		const mockPush = jest.fn();
+		jest.requireMock('react-router-dom').useHistory.mockReturnValue({
+			push: mockPush,
+		});
+
+		useAuth.mockReturnValue({
+			auth: {
+				tenants: undefined,
+			},
+			currentTenant: 'f24965fc1b9c11106daea681f54bcb04',
+		});
+
+		rtRender(<ChairDashboard />);
+
+		await waitFor(() => {
+			expect(axios.get).not.toHaveBeenCalled();
+			expect(mockPush).not.toHaveBeenCalled();
+			expect(message.error).not.toHaveBeenCalled();
+		});
+	});
+
 	test('<ChairDashboard /> should display error message when API fails', async () => {
 		axios.get.mockRejectedValue(new Error('API Error'));
 		const notificationErrorSpy = jest.spyOn(notification, 'error');

--- a/src/containers/ChairDashboard/ChairDashboard.test.js
+++ b/src/containers/ChairDashboard/ChairDashboard.test.js
@@ -557,23 +557,34 @@ describe('ChairDashboard component tests', () => {
 		expect(await screen.findByText('0 applicants')).toBeInTheDocument();
 	});
 
-	test('<ChairDashboard /> should handle validateVacancyData returning object without list', async () => {
+	test('<ChairDashboard /> should handle API returning result without list', async () => {
 		const mockPush = jest.fn();
 		jest.requireMock('react-router-dom').useHistory.mockReturnValue({
 			push: mockPush,
 		});
 
-		isChair.mockReturnValueOnce(true);
+		useAuth.mockReturnValue({
+			auth: {
+				tenants: [
+					{
+						value: 'f24965fc1b9c11106daea681f54bcb04',
+						label: 'tenant 1',
+						is_chair: true,
+					},
+				],
+			},
+			currentTenant: 'f24965fc1b9c11106daea681f54bcb04',
+		});
+		isChair.mockReturnValue(true);
 		
-		// Mock validateVacancyData to return object without list property
-		const validateVacancyDataModule = require('./Utils/validateVacancyData');
-		jest.spyOn(validateVacancyDataModule, 'validateVacancyData').mockReturnValueOnce({});
+		const notificationErrorSpy = jest.spyOn(notification, 'error');
 		
+		// Mock API to return result object without list property
 		axios.get.mockResolvedValueOnce({
 			data: {
 				result: {
 					status: 200,
-					list: [{ vacancy_id: 1, vacancy_title: 'Test', status: 'open' }],
+					message: 'Some message but no list',
 				},
 			},
 		});
@@ -581,12 +592,9 @@ describe('ChairDashboard component tests', () => {
 		rtRender(<ChairDashboard />);
 
 		await waitFor(() => {
-			expect(
-				screen.getByText(
-					'Sorry! You do not have any vacancies assigned to you in the selected tenant.'
-				)
-			).toBeInTheDocument();
+			expect(notificationErrorSpy).toHaveBeenCalledTimes(1);
 		});
-		expect(mockPush).toHaveBeenCalledWith('/');
+		
+		notificationErrorSpy.mockRestore();
 	});
 });

--- a/src/containers/CommitteeDashboard/CommitteeDashboard.js
+++ b/src/containers/CommitteeDashboard/CommitteeDashboard.js
@@ -61,83 +61,127 @@ const committeeDashboard = () => {
 		</div>
 	);
 
-	useEffect(() => {
-		if (currentTenant) {
-			if (
-				validateRoleForCurrentTenant(
-					COMMITTEE_MEMBER_ROLE,
-					currentTenant,
-					tenants
-				) ||
-				isExecSec(currentTenant, tenants)
-			) {
-				(async () => {
-					setHasError(false);
-					setIsLoading(true);
-					try {
-						setreadOnly(user.isReadOnlyUser);
-						const url = GET_COMMITTEE_MEMBER_VIEW + currentTenant;
-						const currentData = await axios.get(url);
+	    useEffect(() => {
+        // Stop immediately if no tenant is selected, notify the user, and go home.
+        if (!currentTenant) {
+            message.destroy();
+            message.error({
+                duration: 3,
+                content: 'Sorry! Please reselect your tenant and try again.',
+            });
+            setIsLoading(false);
+            history.push('/');
+            return;
+        }
 
-						const jsonData = currentData.data.result;
+        // Wait until auth data has loaded before checking roles or reading user fields.
+        if (!user || !Array.isArray(tenants)) {
+            return;
+        }
 
-						const validatedData = validateVacancyData(jsonData);
+        // Allow this dashboard only for committee members in the selected tenant
+        // or executive secretaries in the selected tenant.
+        const hasCommitteeAccess =
+            validateRoleForCurrentTenant(
+                COMMITTEE_MEMBER_ROLE,
+                currentTenant,
+                tenants
+            ) ||
+            isExecSec(currentTenant, tenants);
 
-						const committeeMemberData =
-							location.pathname === EXE_SEC_DASHBOARD
-								? validatedData?.list.filter(
-										(vacancy) => vacancy.user_role === COMMITTEE_EXEC_SEC
-									)
-								: validatedData?.list;
-						setData(committeeMemberData);
-					} catch (err) {
-						setHasError(true);
-						notification.error({
-							message: 'Sorry! There was an error retrieving vacancies.',
-							description: (
-								<>
-									<p>
-										Please refresh the page and try again or try logging out and
-										logging back in. If the issue persists, contact the Help
-										Desk by emailing{' '}
-										<a href='mailto:NCIAppSupport@mail.nih.gov'>
-											NCIAppSupport@mail.nih.gov
-										</a>
-									</p>
-								</>
-							),
-							duration: 30,
-							style: {
-								height: '225px',
-								display: 'flex',
-								alignItems: 'center',
-							},
-						});
-					} finally {
-						setIsLoading(false);
-					}
-				})();
-			} else {
-				message.destroy();
-				message.error({
-					duration: 3,
-					content:
-						'Sorry! You do not have committee member access in the selected tenant.',
-				});
-				setIsLoading(false);
-				history.push('/');
-			}
-		} else {
-			message.destroy();
-			message.error({
-				duration: 3,
-				content:
-					'Sorry! Please reselect your tenant and try again.'
-			});
-			setIsLoading(false);
-			history.push('/');
-		}
-	}, [currentTenant]);
+        // If the user does not have access in the selected tenant, notify and redirect.
+        if (!hasCommitteeAccess) {
+            message.destroy();
+            message.error({
+                duration: 3,
+                content:
+                    'Sorry! You do not have committee member access in the selected tenant.',
+            });
+            setIsLoading(false);
+            history.push('/');
+            return;
+        }
+
+        // Track whether this effect is still current so async work does not update stale state.
+        let isMounted = true;
+
+        (async () => {
+            // Reset error state and show loading before fetching vacancy data.
+            setHasError(false);
+            setIsLoading(true);
+
+            try {
+                // Read the current user's read-only flag once auth is available.
+                setreadOnly(!!user.isReadOnlyUser);
+
+                // Fetch the committee vacancy view for the selected tenant.
+                const url = GET_COMMITTEE_MEMBER_VIEW + currentTenant;
+                const currentData = await axios.get(url);
+                const jsonData = currentData.data.result;
+
+                // Validate the API payload and normalize access to the vacancy list.
+                const validatedData = validateVacancyData(jsonData);
+
+                // On the executive secretary route, only keep executive secretary rows.
+                // On the normal committee dashboard route, use the full list.
+                const committeeMemberData =
+                    location.pathname === EXE_SEC_DASHBOARD
+                        ? validatedData?.list.filter(
+                                (vacancy) => vacancy.user_role === COMMITTEE_EXEC_SEC
+                          )
+                        : validatedData?.list;
+
+                // Stop if the component unmounted or the effect was replaced while waiting.
+                if (!isMounted) {
+                    return;
+                }
+
+                // Save the rows so the table can render them.
+                setData(committeeMemberData);
+            } catch (err) {
+                // Stop if the effect is no longer current before updating UI state.
+                if (!isMounted) {
+                    return;
+                }
+
+                // Show the fallback error UI and notification if the request fails
+                // or the response cannot be processed.
+                setHasError(true);
+                notification.error({
+                    message: 'Sorry! There was an error retrieving vacancies.',
+                    description: (
+                        <>
+                            <p>
+                                Please refresh the page and try again or try logging out and
+                                logging back in. If the issue persists, contact the Help Desk by
+                                emailing{' '}
+                                <a href='mailto:NCIAppSupport@mail.nih.gov'>
+                                    NCIAppSupport@mail.nih.gov
+                                </a>
+                            </p>
+                        </>
+                    ),
+                    duration: 30,
+                    style: {
+                        height: '225px',
+                        display: 'flex',
+                        alignItems: 'center',
+                    },
+                });
+            } finally {
+                // Turn off loading only if this effect instance is still active.
+                if (isMounted) {
+                    setIsLoading(false);
+                }
+            }
+        })();
+
+        // Cleanup marks this effect instance as stale so late async completions
+        // do not update state after unmount or dependency changes.
+        return () => {
+            isMounted = false;
+        };
+    }, [currentTenant, user, tenants, location.pathname, history]);
 
 	return hasError ? (
 		<div className='Content'>

--- a/src/containers/CommitteeDashboard/CommitteeDashboard.js
+++ b/src/containers/CommitteeDashboard/CommitteeDashboard.js
@@ -23,7 +23,7 @@ import {
 	validateRoleForCurrentTenant,
 	isExecSec,
 } from '../../components/Util/RoleValidator/RoleValidator';
-import { validateVacancyData } from '../ChairDashboard/Utils/validateVacancyData.js';
+// import { validateVacancyData } from '../ChairDashboard/Utils/validateVacancyData.js';
 import {
 	normalizeStatus,
 	compareStatus,
@@ -61,127 +61,131 @@ const committeeDashboard = () => {
 		</div>
 	);
 
-	    useEffect(() => {
-        // Stop immediately if no tenant is selected, notify the user, and go home.
-        if (!currentTenant) {
-            message.destroy();
-            message.error({
-                duration: 3,
-                content: 'Sorry! Please reselect your tenant and try again.',
-            });
-            setIsLoading(false);
-            history.push('/');
-            return;
-        }
+	useEffect(() => {
+		console.log('CommitteeDashboard mount/update', {
+			currentTenant,
+			pathname: location.pathname,
+			currentDataLength: Array.isArray(data) ? data.length : 'not-array',
+		});
 
-        // Wait until auth data has loaded before checking roles or reading user fields.
-        if (!user || !Array.isArray(tenants)) {
-            return;
-        }
+		if (currentTenant) {
+			if (!tenants) {
+				// Wait for tenants to load
+				console.log('CommitteeDashboard waiting for tenants to load');
+				return;
+			}
 
-        // Allow this dashboard only for committee members in the selected tenant
-        // or executive secretaries in the selected tenant.
-        const hasCommitteeAccess =
-            validateRoleForCurrentTenant(
-                COMMITTEE_MEMBER_ROLE,
-                currentTenant,
-                tenants
-            ) ||
-            isExecSec(currentTenant, tenants);
+			if (
+				validateRoleForCurrentTenant(
+					COMMITTEE_MEMBER_ROLE,
+					currentTenant,
+					tenants
+				) ||
+				isExecSec(currentTenant, tenants)
+			) {
+				(async () => {
+					setHasError(false);
+					setIsLoading(true);
+					try {
+						console.log('CommitteeDashboard fetching vacancies', {
+							currentTenant,
+							pathname: location.pathname,
+							userRoleCount: tenants?.length,
+						});
+						setreadOnly(!!user?.isReadOnlyUser);
+						const url = GET_COMMITTEE_MEMBER_VIEW + currentTenant;
+						const currentData = await axios.get(url);
+						console.log('CommitteeDashboard API response', currentData?.data);
 
-        // If the user does not have access in the selected tenant, notify and redirect.
-        if (!hasCommitteeAccess) {
-            message.destroy();
-            message.error({
-                duration: 3,
-                content:
-                    'Sorry! You do not have committee member access in the selected tenant.',
-            });
-            setIsLoading(false);
-            history.push('/');
-            return;
-        }
+						const jsonData = currentData?.data?.result || {};
+						console.log('CommitteeDashboard result payload', jsonData);
+						// const validatedData = validateVacancyData(jsonData);
 
-        // Track whether this effect is still current so async work does not update stale state.
-        let isMounted = true;
+					// Validate that result has required list field
+					if (!Array.isArray(jsonData?.list)) {
+						throw new Error('API response missing required list field');
+					}
 
-        (async () => {
-            // Reset error state and show loading before fetching vacancy data.
-            setHasError(false);
-            setIsLoading(true);
+					const vacancyList = jsonData.list;
+						console.log('CommitteeDashboard vacancy list', {
+						isArray: Array.isArray(vacancyList),
+							length: vacancyList.length,
+						});
 
-            try {
-                // Read the current user's read-only flag once auth is available.
-                setreadOnly(!!user.isReadOnlyUser);
+						const validVacancies = vacancyList.filter(v =>
+							v && v.vacancy_id && v.vacancy_title && v.status !== undefined
+						);
+						console.log('CommitteeDashboard validated vacancies', {
+							originalLength: vacancyList.length,
+							validLength: validVacancies.length,
+						});
 
-                // Fetch the committee vacancy view for the selected tenant.
-                const url = GET_COMMITTEE_MEMBER_VIEW + currentTenant;
-                const currentData = await axios.get(url);
-                const jsonData = currentData.data.result;
+						const committeeMemberData =
+							location.pathname === EXE_SEC_DASHBOARD
+								? validVacancies.filter(
+									(vacancy) => vacancy.user_role === COMMITTEE_EXEC_SEC
+								)
+								: validVacancies;
 
-                // Validate the API payload and normalize access to the vacancy list.
-                const validatedData = validateVacancyData(jsonData);
-
-                // On the executive secretary route, only keep executive secretary rows.
-                // On the normal committee dashboard route, use the full list.
-                const committeeMemberData =
-                    location.pathname === EXE_SEC_DASHBOARD
-                        ? validatedData?.list.filter(
-                                (vacancy) => vacancy.user_role === COMMITTEE_EXEC_SEC
-                          )
-                        : validatedData?.list;
-
-                // Stop if the component unmounted or the effect was replaced while waiting.
-                if (!isMounted) {
-                    return;
-                }
-
-                // Save the rows so the table can render them.
-                setData(committeeMemberData);
-            } catch (err) {
-                // Stop if the effect is no longer current before updating UI state.
-                if (!isMounted) {
-                    return;
-                }
-
-                // Show the fallback error UI and notification if the request fails
-                // or the response cannot be processed.
-                setHasError(true);
-                notification.error({
-                    message: 'Sorry! There was an error retrieving vacancies.',
-                    description: (
-                        <>
-                            <p>
-                                Please refresh the page and try again or try logging out and
-                                logging back in. If the issue persists, contact the Help Desk by
-                                emailing{' '}
-                                <a href='mailto:NCIAppSupport@mail.nih.gov'>
-                                    NCIAppSupport@mail.nih.gov
-                                </a>
-                            </p>
-                        </>
-                    ),
-                    duration: 30,
-                    style: {
-                        height: '225px',
-                        display: 'flex',
-                        alignItems: 'center',
-                    },
-                });
-            } finally {
-                // Turn off loading only if this effect instance is still active.
-                if (isMounted) {
-                    setIsLoading(false);
-                }
-            }
-        })();
-
-        // Cleanup marks this effect instance as stale so late async completions
-        // do not update state after unmount or dependency changes.
-        return () => {
-            isMounted = false;
-        };
-    }, [currentTenant, user, tenants, location.pathname, history]);
+						console.log('CommitteeDashboard derived table rows', {
+							length: committeeMemberData.length,
+							firstRow: committeeMemberData[0],
+						});
+						setData(committeeMemberData);
+					} catch (err) {
+						console.error('CommitteeDashboard load failed', err);
+						console.error('CommitteeDashboard error details:', {
+							message: err?.message,
+							stack: err?.stack,
+							name: err?.name,
+						});
+						setHasError(true);
+						notification.error({
+							message: 'Sorry! There was an error retrieving vacancies.',
+							description: (
+								<>
+									<p>
+										Please refresh the page and try again or try logging out and
+										logging back in. If the issue persists, contact the Help
+										Desk by emailing{' '}
+										<a href='mailto:NCIAppSupport@mail.nih.gov'>
+											NCIAppSupport@mail.nih.gov
+										</a>
+									</p>
+								</>
+							),
+							duration: 30,
+							style: {
+								height: '225px',
+								display: 'flex',
+								alignItems: 'center',
+							},
+						});
+					} finally {
+						setIsLoading(false);
+					}
+				})();
+			} else {
+				message.destroy();
+				message.error({
+					duration: 3,
+					content:
+						'Sorry! You do not have committee member access in the selected tenant.',
+				});
+				setIsLoading(false);
+				history.push('/');
+			}
+		} else {
+			message.destroy();
+			message.error({
+				duration: 3,
+				content:
+					'Sorry! Please reselect your tenant and try again.'
+			});
+			setIsLoading(false);
+			history.push('/');
+		}
+	}, [currentTenant, tenants, user, location.pathname]);
 
 	return hasError ? (
 		<div className='Content'>

--- a/src/containers/CommitteeDashboard/CommitteeDashboard.js
+++ b/src/containers/CommitteeDashboard/CommitteeDashboard.js
@@ -23,7 +23,6 @@ import {
 	validateRoleForCurrentTenant,
 	isExecSec,
 } from '../../components/Util/RoleValidator/RoleValidator';
-// import { validateVacancyData } from '../ChairDashboard/Utils/validateVacancyData.js';
 import {
 	normalizeStatus,
 	compareStatus,
@@ -65,7 +64,7 @@ const committeeDashboard = () => {
 		console.log('CommitteeDashboard mount/update', {
 			currentTenant,
 			pathname: location.pathname,
-			currentDataLength: Array.isArray(data) ? data.length : 'not-array',
+			currentDataLength: data?.length ?? 0,
 		});
 
 		if (currentTenant) {
@@ -108,7 +107,7 @@ const committeeDashboard = () => {
 
 					const vacancyList = jsonData.list;
 						console.log('CommitteeDashboard vacancy list', {
-						isArray: Array.isArray(vacancyList),
+							isArray: Array.isArray(vacancyList),
 							length: vacancyList.length,
 						});
 

--- a/src/containers/CommitteeDashboard/CommitteeDashboard.test.js
+++ b/src/containers/CommitteeDashboard/CommitteeDashboard.test.js
@@ -174,6 +174,30 @@ describe('CommitteeDashboard component tests', () => {
 		expect(axios.get).not.toHaveBeenCalled();
 	});
 
+	test('<CommitteeDashboard /> should wait for tenants to load before checking access', async () => {
+		const mockPush = jest.fn();
+		const antd = jest.requireMock('antd');
+		jest.requireMock('react-router-dom').useHistory.mockReturnValue({
+			push: mockPush,
+		});
+
+		useAuth.mockReturnValue({
+			auth: {
+				tenants: undefined,
+				user: { isReadOnlyUser: false },
+			},
+			currentTenant: 'tenant1',
+		});
+
+		rtRender(<CommitteeDashboard />);
+
+		await waitFor(() => {
+			expect(axios.get).not.toHaveBeenCalled();
+			expect(mockPush).not.toHaveBeenCalled();
+			expect(antd.message.error).not.toHaveBeenCalled();
+		});
+	});
+
 	test('<CommitteeDashboard /> should display error when invalid list shape is provided', async () => {
 		// Test that invalid list shape throws and triggers error UI
 		const invalidData = {

--- a/webpack/servicenow.config.js
+++ b/webpack/servicenow.config.js
@@ -15,8 +15,12 @@ const servicenowConfig = {
 	 * it is being used for sending REST calls in DEVELOPMENT mode only
 	 * no need to provide credentials for PRODUCTION
 	 */
-REACT_APP_USER: 'jaya.chakladar.test.user@gmail.com',
-REACT_APP_PASSWORD: 'Simba517!',
+	REACT_APP_USER: '',
+	/**
+	 *
+	 * User password, for DEVELOPMENT mode only
+	 */
+	REACT_APP_PASSWORD: '',
 	/**
 	 *
 	 * ServiceNow path to GET resource which serves javascript files

--- a/webpack/servicenow.config.js
+++ b/webpack/servicenow.config.js
@@ -15,12 +15,8 @@ const servicenowConfig = {
 	 * it is being used for sending REST calls in DEVELOPMENT mode only
 	 * no need to provide credentials for PRODUCTION
 	 */
-	REACT_APP_USER: '',
-	/**
-	 *
-	 * User password, for DEVELOPMENT mode only
-	 */
-	REACT_APP_PASSWORD: '',
+REACT_APP_USER: 'jaya.chakladar.test.user@gmail.com',
+REACT_APP_PASSWORD: 'Simba517!',
 	/**
 	 *
 	 * ServiceNow path to GET resource which serves javascript files


### PR DESCRIPTION
This fixes [SSJ-757](https://tracker.nci.nih.gov/browse/SSJ-757)

## Summary

This update hardens the `useEffect` flows in CommitteeDashboard.js and ChairDashboard.js so they wait for required auth/tenant data before checking access or fetching dashboard data. It also adds defensive validation on API responses to ensure array methods (`.filter()`, `.some()`) are only called on actual arrays.

The goal is to fix production crashes where dashboards could:
- Evaluate access before tenants loaded, causing false redirects
- Call `.filter()` or `.some()` on non-array API responses, resulting in white screens
- Show error states when API responses were actually valid but structurally different than expected

**Key Changes:**
- Added `if (!tenants) return;` guard to wait for auth state
- Replaced unsafe `validateVacancyData()` utility with inline `Array.isArray()` validation
- Updated useEffect dependency arrays to include all reactive variables: `[currentTenant, tenants]`
- Handles both API response formats (direct array and object with `list` property)
- Added comprehensive logging at each data transformation step for production debugging
- Improved error messages with detailed stack traces when validation fails
- Updated tests to verify defensive validation triggers proper error handling

## Testing

1. Hard refresh on committee member dashboard with a valid selected tenant
   - [ ] Verify vacancies load and display correctly
   - [ ] Check console shows no `TypeError` exceptions
   - [ ] Confirm no white screen or error overlays

2. Hard refresh on executive secretary dashboard with a valid selected tenant
   - [ ] Verify filtered vacancies (only `user_role: "Executive Secretary"`) display
   - [ ] Check console shows no errors
   - [ ] Confirm data loads without "Sorry! An error occurred." message

3. Hard refresh on chair dashboard with a valid selected tenant
   - [ ] Verify assigned vacancies load
   - [ ] Confirm only non-'live' and non-'final' status vacancies appear
   - [ ] Check console shows no `TypeError` exceptions

4. Select a tenant from dropdown, then navigate to each dashboard
   - [ ] Committee dashboard loads for new tenant
   - [ ] Executive secretary dashboard loads correctly
   - [ ] Chair dashboard reloads with new tenant data

5. Verify valid vacancy responses render correctly
   - [ ] Committee dashboard: All vacancy fields display (title, status, applicants)
   - [ ] Executive secretary dashboard: Only matching role vacancies show
   - [ ] Chair dashboard: Correct status filtering applied

6. Verify missing tenant and unauthorized access show intended behavior
   - [ ] No role access: "You do not have any vacancies assigned" message
   - [ ] Invalid tenant selected: "Please reselect your tenant" message
   - [ ] Missing `list` field in API response: "Sorry! There was an error retrieving vacancies" with Help Desk info

7. Run unit tests
   ```bash
   npm test -- CommitteeDashboard.test.js --no-coverage
   npm test -- ChairDashboard.test.js --no-coverage
   ```
   - [ ] All tests pass

## Risk

**Low to moderate.** Changes are localized to dashboard `useEffect` logic and API response validation, but they affect:
- Auth timing and when tenants load
- Redirects based on role/tenant validation
- Data loading and error state transitions

**Main risks:** Unintended changes in redirect timing or loading state clearing on role/tenant changes. The defensive array validation is safe—it only prevents crashes on malformed responses.

**Mitigation:** Route-level regression testing on all three dashboard flows (committee member, executive secretary, chair) with various user types and tenant selections.

<img width="1131" height="271" alt="Screenshot 2026-06-08 at 3 59 36 PM" src="https://github.com/user-attachments/assets/0a28e321-70ef-4df8-9b4a-f67933346987" />


<img width="501" height="296" alt="Screenshot 2026-06-08 at 3 57 52 PM" src="https://github.com/user-attachments/assets/b98ecfe1-389f-4ace-992a-58890fde09ce" />


